### PR TITLE
Add basic admin UI and DB helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ GOOGLE_SCOPES=https://www.googleapis.com/auth/contacts
 GOOGLE_REDIRECT_URI=http://localhost:8000/oauth/google/callback
 WEBHOOK_SHARED_SECRET=
 LOG_LEVEL=INFO
+
+ADMIN_BASIC_USER=admin
+ADMIN_BASIC_PASS=change-me

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Visit `/auth/google/start` and `/auth/amocrm/start` to complete OAuth flows.
 ```bash
 pytest
 ```
+
+## Admin interface
+
+The admin UI is available at `/admin` and is protected with HTTP Basic Auth.
+Set `ADMIN_BASIC_USER` and `ADMIN_BASIC_PASS` in environment (see `.env.example`).
+It provides pages to manage users and jobs. Remove the credentials to disable the interface (requests to `/admin` will return 404).

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,245 @@
+import base64
+import csv
+import logging
+import os
+from datetime import datetime
+from io import StringIO
+from typing import Optional
+
+from aiohttp import web
+
+import db
+
+log = logging.getLogger(__name__)
+
+ADMIN_BASIC_USER = os.getenv("ADMIN_BASIC_USER")
+ADMIN_BASIC_PASS = os.getenv("ADMIN_BASIC_PASS")
+
+
+async def require_admin(request: web.Request) -> None:
+    if not ADMIN_BASIC_USER or not ADMIN_BASIC_PASS:
+        raise web.HTTPNotFound()
+    auth = request.headers.get("Authorization")
+    if not auth or not auth.startswith("Basic "):
+        raise web.HTTPUnauthorized(headers={"WWW-Authenticate": 'Basic realm="ttn-bot admin"'})
+    try:
+        decoded = base64.b64decode(auth[6:]).decode()
+    except Exception:  # pragma: no cover - malformed base64
+        raise web.HTTPUnauthorized(headers={"WWW-Authenticate": 'Basic realm="ttn-bot admin"'})
+    username, _, password = decoded.partition(":")
+    if username != ADMIN_BASIC_USER or password != ADMIN_BASIC_PASS:
+        raise web.HTTPUnauthorized(headers={"WWW-Authenticate": 'Basic realm="ttn-bot admin"'})
+
+
+def render_page(title: str, body: str) -> web.Response:
+    nav = '<nav><a href="/admin">Dashboard</a> | <a href="/admin/users">Users</a> | <a href="/admin/jobs">Jobs</a></nav>'
+    html = f"""
+    <html>
+    <head>
+        <title>{title}</title>
+        <style>
+            body {{ font-family: sans-serif; margin: 20px; }}
+            table {{ border-collapse: collapse; width: 100%; }}
+            th, td {{ border: 1px solid #ddd; padding: 8px; }}
+            th {{ background: #f4f4f4; }}
+            nav a {{ margin-right: 10px; }}
+        </style>
+    </head>
+    <body>
+        {nav}
+        <h1>{title}</h1>
+        {body}
+    </body>
+    </html>
+    """
+    return web.Response(text=html, content_type="text/html")
+
+
+async def admin_dashboard(request: web.Request) -> web.Response:
+    await require_admin(request)
+    ym = datetime.utcnow().strftime("%Y-%m")
+    stats = await db.month_dashboard(ym)
+    body = f"""
+    <p>Month: {ym}</p>
+    <ul>
+        <li>Users total: {stats['users_total']}</li>
+        <li>Users active: {stats['users_active']}</li>
+        <li>Jobs this month: {stats['jobs_month']}</li>
+        <li>Cost this month USD: {stats['cost_month_usd']}</li>
+    </ul>
+    <p><a href="/admin/users">Users</a> | <a href="/admin/jobs">Jobs</a></p>
+    """
+    log.info("admin dashboard viewed")
+    return render_page("Admin Dashboard", body)
+
+
+async def admin_users(request: web.Request) -> web.Response:
+    await require_admin(request)
+    ym = request.query.get("ym") or datetime.utcnow().strftime("%Y-%m")
+    users = await db.list_users_with_month_stats(ym)
+    rows = "".join(
+        f"<tr><td>{u['user_id']}</td><td>{u['username'] or ''}</td><td>{u['full_name'] or ''}</td>"
+        f"<td>{'yes' if u['active'] else 'no'}</td><td>{u['last_seen'] or ''}</td>"
+        f"<td>{u['jobs_this_month']}</td><td>{u['cost_this_month_usd']}</td>"
+        f"<td>"
+        f"<form method='post' action='/admin/users/{'block' if u['active'] else 'unblock'}'>"
+        f"<input type='hidden' name='user_id' value='{u['user_id']}'/>"
+        f"<button type='submit'>{'Block' if u['active'] else 'Unblock'}</button>"
+        f"</form></td></tr>"
+        for u in users
+    )
+    body = f"""
+    <form method="get">
+        Month: <input type="text" name="ym" value="{ym}"/>
+        <button type="submit">Filter</button>
+    </form>
+    <h2>Add user</h2>
+    <form method="post" action="/admin/users/add">
+        ID: <input type="number" name="user_id" required/>
+        Username: <input type="text" name="username"/>
+        Full name: <input type="text" name="full_name"/>
+        <button type="submit">Save</button>
+    </form>
+    <h2>Users</h2>
+    <table>
+        <tr><th>ID</th><th>Username</th><th>Full name</th><th>Active</th><th>Last seen</th><th>Jobs</th><th>Cost USD</th><th>Action</th></tr>
+        {rows}
+    </table>
+    """
+    log.info("admin users viewed")
+    return render_page("Users", body)
+
+
+async def admin_users_add(request: web.Request) -> web.Response:
+    await require_admin(request)
+    form = await request.post()
+    user_id = int(form["user_id"])
+    username = form.get("username") or None
+    full_name = form.get("full_name") or None
+    await db.insert_user_manual(user_id, username, full_name)
+    log.info("user %s added/updated", user_id)
+    raise web.HTTPFound("/admin/users")
+
+
+async def admin_users_block(request: web.Request) -> web.Response:
+    await require_admin(request)
+    form = await request.post()
+    user_id = int(form["user_id"])
+    await db.block_user(user_id, False)
+    log.info("user %s blocked", user_id)
+    raise web.HTTPFound("/admin/users")
+
+
+async def admin_users_unblock(request: web.Request) -> web.Response:
+    await require_admin(request)
+    form = await request.post()
+    user_id = int(form["user_id"])
+    await db.block_user(user_id, True)
+    log.info("user %s unblocked", user_id)
+    raise web.HTTPFound("/admin/users")
+
+
+async def admin_jobs(request: web.Request) -> web.Response:
+    await require_admin(request)
+    ym = request.query.get("ym") or datetime.utcnow().strftime("%Y-%m")
+    user_id = request.query.get("user_id")
+    user_id_int: Optional[int] = int(user_id) if user_id else None
+    jobs = await db.list_jobs(ym, user_id_int)
+    rows = "".join(
+        f"<tr><td>{j['job_id']}</td><td>{j['user_id']}</td><td>{j['filename'] or ''}</td>"
+        f"<td>{j['status']}</td><td>{j['started_at']}</td><td>{j['finished_at'] or ''}</td>"
+        f"<td>{j['took_sec'] or ''}</td><td>{j['tokens_prompt'] or ''}</td>"
+        f"<td>{j['tokens_completion'] or ''}</td><td>{j['cost_usd'] or ''}</td>"
+        f"<td>{j['model']}</td><td>{j['schema_version']}</td></tr>"
+        for j in jobs
+    )
+    csv_link = f"/admin/jobs.csv?ym={ym}" + (f"&user_id={user_id_int}" if user_id_int else "")
+    body = f"""
+    <form method="get">
+        Month: <input type="text" name="ym" value="{ym}"/>
+        User ID: <input type="text" name="user_id" value="{user_id or ''}"/>
+        <button type="submit">Filter</button>
+    </form>
+    <p><a href="{csv_link}">Export CSV</a></p>
+    <table>
+        <tr><th>ID</th><th>User</th><th>Filename</th><th>Status</th><th>Started</th><th>Finished</th><th>Took</th><th>Prompt</th><th>Completion</th><th>Cost USD</th><th>Model</th><th>Schema</th></tr>
+        {rows}
+    </table>
+    """
+    log.info("admin jobs viewed")
+    return render_page("Jobs", body)
+
+
+async def admin_jobs_csv(request: web.Request) -> web.Response:
+    await require_admin(request)
+    ym = request.query.get("ym") or datetime.utcnow().strftime("%Y-%m")
+    user_id = request.query.get("user_id")
+    user_id_int: Optional[int] = int(user_id) if user_id else None
+    jobs = await db.list_jobs(ym, user_id_int)
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow([
+        "job_id",
+        "user_id",
+        "filename",
+        "status",
+        "started_at",
+        "finished_at",
+        "took_sec",
+        "tokens_prompt",
+        "tokens_completion",
+        "cost_usd",
+        "model",
+        "schema_version",
+    ])
+    for j in jobs:
+        writer.writerow([
+            j["job_id"],
+            j["user_id"],
+            j["filename"],
+            j["status"],
+            j["started_at"],
+            j["finished_at"],
+            j["took_sec"],
+            j["tokens_prompt"],
+            j["tokens_completion"],
+            j["cost_usd"],
+            j["model"],
+            j["schema_version"],
+        ])
+    csv_data = buffer.getvalue()
+    filename = f"jobs-{ym}.csv"
+    headers = {
+        "Content-Disposition": f'attachment; filename="{filename}"'
+    }
+    log.info("admin jobs csv exported")
+    return web.Response(text=csv_data, content_type="text/csv", headers=headers)
+
+
+async def health(request: web.Request) -> web.Response:
+    return web.Response(text="ok")
+
+
+async def webhook(request: web.Request) -> web.Response:
+    data = await request.json()
+    return web.json_response({"ok": True, "received": data})
+
+
+def create_app() -> web.Application:
+    app = web.Application()
+    app.add_routes([
+        web.get("/health", health),
+        web.post("/webhook", webhook),
+        web.get("/admin", admin_dashboard),
+        web.get("/admin/users", admin_users),
+        web.post("/admin/users/add", admin_users_add),
+        web.post("/admin/users/block", admin_users_block),
+        web.post("/admin/users/unblock", admin_users_unblock),
+        web.get("/admin/jobs", admin_jobs),
+        web.get("/admin/jobs.csv", admin_jobs_csv),
+    ])
+    return app
+
+
+if __name__ == "__main__":
+    web.run_app(create_app())

--- a/db.py
+++ b/db.py
@@ -1,0 +1,108 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import asyncpg
+
+_pool: Optional[asyncpg.pool.Pool] = None
+
+
+async def init_db_pool(dsn: Optional[str] = None) -> None:
+    """Initialize connection pool using provided DSN or DATABASE_URL env."""
+    global _pool
+    if _pool is None:
+        dsn = dsn or os.getenv("DATABASE_URL")
+        if dsn is None:
+            raise RuntimeError("DATABASE_URL is not configured")
+        _pool = await asyncpg.create_pool(dsn)
+
+
+async def list_users_with_month_stats(ym: str) -> List[asyncpg.Record]:
+    """Return users with monthly job stats."""
+    assert _pool is not None, "DB pool is not initialized"
+    sql = """
+        SELECT u.user_id, u.username, u.full_name, u.active, u.last_seen,
+               COALESCE(j.jobs_this_month, 0) AS jobs_this_month,
+               COALESCE(j.cost_this_month_usd, 0) AS cost_this_month_usd
+        FROM users u
+        LEFT JOIN (
+            SELECT user_id,
+                   COUNT(*) AS jobs_this_month,
+                   COALESCE(SUM(cost_usd), 0) AS cost_this_month_usd
+            FROM jobs
+            WHERE to_char(started_at, 'YYYY-MM') = $1
+            GROUP BY user_id
+        ) j ON j.user_id = u.user_id
+        ORDER BY u.user_id
+    """
+    async with _pool.acquire() as conn:
+        return await conn.fetch(sql, ym)
+
+
+async def block_user(user_id: int, active: bool) -> None:
+    """Set active flag for user."""
+    assert _pool is not None, "DB pool is not initialized"
+    async with _pool.acquire() as conn:
+        await conn.execute("UPDATE users SET active=$2 WHERE user_id=$1", user_id, active)
+
+
+async def insert_user_manual(
+    user_id: int, username: Optional[str], full_name: Optional[str]
+) -> None:
+    """Upsert user created manually."""
+    assert _pool is not None, "DB pool is not initialized"
+    async with _pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (user_id, username, full_name, active)
+            VALUES ($1, $2, $3, true)
+            ON CONFLICT (user_id) DO UPDATE
+            SET username = EXCLUDED.username,
+                full_name = EXCLUDED.full_name
+            """,
+            user_id,
+            username,
+            full_name,
+        )
+
+
+async def month_dashboard(ym: str) -> Dict[str, Any]:
+    """Return dashboard aggregates for a month."""
+    assert _pool is not None, "DB pool is not initialized"
+    async with _pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                (SELECT COUNT(*) FROM users) AS users_total,
+                (SELECT COUNT(*) FROM users WHERE active) AS users_active,
+                (SELECT COUNT(*) FROM jobs WHERE to_char(started_at,'YYYY-MM')=$1) AS jobs_month,
+                (
+                    SELECT COALESCE(SUM(cost_usd),0)
+                    FROM jobs WHERE to_char(started_at,'YYYY-MM')=$1
+                ) AS cost_month_usd
+            """,
+            ym,
+        )
+        return dict(row)
+
+
+async def list_jobs(ym: Optional[str], user_id: Optional[int]) -> List[asyncpg.Record]:
+    """List jobs filtered by month and optionally user_id."""
+    assert _pool is not None, "DB pool is not initialized"
+    conditions = []
+    params: List[Any] = []
+    if ym:
+        params.append(ym)
+        conditions.append(f"to_char(started_at,'YYYY-MM') = ${len(params)}")
+    if user_id is not None:
+        params.append(user_id)
+        conditions.append(f"user_id = ${len(params)}")
+    where = " WHERE " + " AND ".join(conditions) if conditions else ""
+    sql = f"""
+        SELECT job_id, user_id, filename, status, started_at, finished_at,
+               EXTRACT(EPOCH FROM (finished_at - started_at)) AS took_sec,
+               tokens_prompt, tokens_completion, cost_usd, model, schema_version
+        FROM jobs{where}
+        ORDER BY job_id DESC
+    """
+    async with _pool.acquire() as conn:
+        return await conn.fetch(sql, *params)


### PR DESCRIPTION
## Summary
- add aiohttp admin dashboard with basic auth and user/job management
- implement asyncpg helpers for users and jobs with monthly stats
- document admin credentials in README and .env.example

## Testing
- `python -m py_compile bot.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_68c51c965a4c8327b0a8b277f3f5e7d0