### PR TITLE
Fix DB session bind + auto-migrations, add Amo long-lived token env fallback, Docker ${PORT}; docs/env update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ AMO_BASE_URL=https://example.amocrm.ru
 AMO_CLIENT_ID=
 AMO_CLIENT_SECRET=
 AMO_REDIRECT_URI=http://localhost:8000/oauth/amocrm/callback
+AMO_LONG_LIVED_TOKEN=            # если заполнено — используем этот Bearer-токен без OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_SCOPES=https://www.googleapis.com/auth/contacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY --from=build /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH
 COPY . .
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ uvicorn app.main:app --reload
 
 Create `.env` from `.env.example` and fill credentials.
 
-## Docker
+## Docker / Render
 
 ```bash
 docker-compose up --build
 ```
+
+### Render
+- Dockerfile уже выполняет `alembic upgrade head` и читает порт из `${PORT}`.
+- Если используете долгосрочный токен Amo:
+  - установите `AMO_LONG_LIVED_TOKEN` в Environment и не проходите OAuth Amo.
 
 ## OAuth
 

--- a/app/amocrm.py
+++ b/app/amocrm.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List
 
+import os
+
 import httpx
 
 from app.config import settings
@@ -10,6 +12,11 @@ AMO_HEADERS = {"Content-Type": "application/json"}
 
 
 async def get_access_token() -> str:
+    # 1) env-фолбэк: используем долгосрочный токен, если задан
+    env_token = os.getenv("AMO_LONG_LIVED_TOKEN") or os.getenv("AMO_ACCESS_TOKEN")
+    if env_token:
+        return env_token
+    # 2) иначе — из БД
     session = get_session()
     token = get_token(session, "amocrm")
     if not token:

--- a/app/main.py
+++ b/app/main.py
@@ -3,9 +3,15 @@ from fastapi import FastAPI
 from app.auth import router as auth_router
 from app.webhooks import router as webhook_router
 from app.backfill import router as backfill_router
+from app.storage import init_db
 
 app = FastAPI()
 
+
+@app.on_event("startup")
+def _startup():
+    # создаём таблицы, если их нет (алембик катается в Docker CMD)
+    init_db()
 
 @app.get("/health")
 async def health() -> dict[str, str]:

--- a/app/storage.py
+++ b/app/storage.py
@@ -27,7 +27,15 @@ def get_engine():
 
 
 def get_session():
+    # гарантируем, что Session привязан к engine
+    get_engine()
     return SessionLocal()
+
+
+def init_db():
+    # fallback на случай, если миграции не катятся — создаём таблицы
+    eng = get_engine()
+    Base.metadata.create_all(eng)
 
 
 class Link(Base):


### PR DESCRIPTION
## Summary
- ensure SQLAlchemy sessions are bound to an engine and create tables on startup as a fallback
- allow supplying AmoCRM access token via `AMO_LONG_LIVED_TOKEN`/`AMO_ACCESS_TOKEN` env vars
- run migrations on container start and honour `${PORT}` in Docker
- document Render specifics and new env var

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a8eb3bb883278447924dd89dc3a9