### PR TITLE
ci: use 'ruff check' in GH Actions (fix lint step)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Lint
-        run: ruff app tests
+        run: ruff check app tests --output-format=github
       - name: Test
         run: pytest


### PR DESCRIPTION
## Summary
- fix GitHub Actions lint step by switching to `ruff check`

## Testing
- `ruff check app tests --output-format=github`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6adc25f048327a8f5975196f383a1