### PR TITLE
ci: unify workflows and use 'ruff check'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Lint
-        run: ruff app tests
+        run: ruff check . --output-format=github
       - name: Test
         run: pytest

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,9 +1,4 @@
-import asyncio
 from logging.config import fileConfig
-
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-
 from alembic import context
 
 from app.storage import Base, get_engine

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,9 +1,8 @@
 from datetime import datetime, timedelta
-from typing import Optional
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import RedirectResponse
 
 from app.config import settings

--- a/app/google_people.py
+++ b/app/google_people.py
@@ -1,9 +1,7 @@
-from datetime import datetime
 from typing import Any, Dict
 
 import httpx
 
-from app.config import settings
 from app.storage import get_session, get_token
 from app.utils import normalize_email, normalize_phone, unique
 


### PR DESCRIPTION
## Summary
- replace deprecated `ruff app tests` with `ruff check . --output-format=github`

## Testing
- `ruff check . --output-format=github` *(fails: F401 imported but unused)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b5372fcc8327b5f72ce52ff6e762