### PR TITLE
fix(db): bind SQLAlchemy SessionLocal and init DB on startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,15 @@ from fastapi import FastAPI
 from app.auth import router as auth_router
 from app.webhooks import router as webhook_router
 from app.backfill import router as backfill_router
+from app.storage import init_db
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def _startup():
+    # Bind engine and ensure tables exist
+    init_db()
 
 
 @app.get("/health")

--- a/app/storage.py
+++ b/app/storage.py
@@ -27,7 +27,15 @@ def get_engine():
 
 
 def get_session():
+    # Ensure engine is created and SessionLocal is bound
+    get_engine()
     return SessionLocal()
+
+
+def init_db():
+    """Create tables if they don't exist (first run / ephemeral FS)."""
+    eng = get_engine()
+    Base.metadata.create_all(bind=eng)
 
 
 class Link(Base):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 httpx
 sqlalchemy
+psycopg[binary]
 alembic
 python-dotenv
 loguru


### PR DESCRIPTION
## Summary
- ensure SQLAlchemy sessions are bound to the engine before use
- automatically create tables on service startup
- add psycopg dependency for PostgreSQL support

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c712225bd48327aac71c5ea8f948dd