### PR TITLE
feat: support X-Debug-Secret header for debug endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Set a shared secret in `DEBUG_SECRET` (e.g. in Render service settings) to enabl
 Example cURL calls:
 
 ```bash
+# Prefer using the X-Debug-Secret header
+curl -H "X-Debug-Secret: $DEBUG_SECRET" "http://localhost:8000/debug/google/ping"
+curl -H "X-Debug-Secret: $DEBUG_SECRET" "http://localhost:8000/debug/google/contacts?limit=3"
+curl -H "X-Debug-Secret: $DEBUG_SECRET" "http://localhost:8000/debug/amo/ping"
+curl -H "X-Debug-Secret: $DEBUG_SECRET" "http://localhost:8000/debug/db/token"
+
+# Legacy query parameter (less preferable)
 curl "http://localhost:8000/debug/google/ping?key=$DEBUG_SECRET"
 curl "http://localhost:8000/debug/google/contacts?limit=3&key=$DEBUG_SECRET"
 curl "http://localhost:8000/debug/amo/ping?key=$DEBUG_SECRET"

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from hmac import compare_digest
+from fastapi import Header, Query, HTTPException, status
+
+from app.config import settings
+
+
+def require_debug_secret(
+    x_debug_secret: str | None = Header(None, alias="X-Debug-Secret"),
+    key: str | None = Query(None),
+) -> None:
+    """Validate debug secret from header or query parameter."""
+    secret = settings.debug_secret
+    if not secret:
+        raise HTTPException(status_code=500, detail="DEBUG_SECRET is not set")
+
+    header_val = x_debug_secret or ""
+    query_val = key or ""
+    if compare_digest(header_val, secret) or compare_digest(query_val, secret):
+        return
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")

--- a/tests/test_debug_auth.py
+++ b/tests/test_debug_auth.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi import HTTPException
+from unittest.mock import patch
+
+from app.config import settings
+from app.security import require_debug_secret
+
+
+def test_header_valid(monkeypatch):
+    monkeypatch.setattr(settings, "debug_secret", "s")
+    require_debug_secret("s", None)
+
+
+def test_query_valid(monkeypatch):
+    monkeypatch.setattr(settings, "debug_secret", "s")
+    require_debug_secret(None, "s")
+
+
+def test_either_valid(monkeypatch):
+    monkeypatch.setattr(settings, "debug_secret", "s")
+    require_debug_secret("wrong", "s")
+
+
+def test_invalid(monkeypatch):
+    monkeypatch.setattr(settings, "debug_secret", "s")
+    with pytest.raises(HTTPException) as exc:
+        require_debug_secret(None, "wrong")
+    assert exc.value.status_code == 401
+    with pytest.raises(HTTPException):
+        require_debug_secret(None, None)
+
+
+def test_compare_digest_used(monkeypatch):
+    monkeypatch.setattr(settings, "debug_secret", "s")
+    with patch("app.security.compare_digest", return_value=False) as mock_cd:
+        with pytest.raises(HTTPException):
+            require_debug_secret(None, None)
+        assert mock_cd.call_count >= 2


### PR DESCRIPTION
## Summary
- add reusable dependency that checks DEBUG_SECRET via `X-Debug-Secret` header or `key` query
- update debug endpoints to use new authorization dependency
- document preferred header auth method in README
- add unit and integration tests for new debug auth

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c72a568a348327968237885a114935