### PR TITLE
Add read-only dry-run contacts sync endpoint

### DIFF
--- a/app/debug.py
+++ b/app/debug.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, List
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Header, Query
 from sqlalchemy import select
 
 from app.config import settings
@@ -12,11 +12,15 @@ from app.storage import Token, get_session, get_token
 router = APIRouter(prefix="/debug", tags=["debug"])
 
 
-def require_debug_key(key: str | None = Query(None)) -> None:
+def require_debug_key(
+    x_debug_secret: str | None = Header(default=None, alias="X-Debug-Secret"),
+    key: str | None = Query(None),
+) -> None:
     secret = settings.debug_secret
     if not secret:
         raise HTTPException(status_code=500, detail="DEBUG_SECRET is not set")
-    if key != secret:
+    provided = x_debug_secret or key
+    if provided != secret:
         raise HTTPException(status_code=403, detail="Forbidden")
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from app.auth import router as auth_router
 from app.webhooks import router as webhook_router
 from app.backfill import router as backfill_router
 from app.debug import router as debug_router
+from app.routes.sync import router as sync_router
 from app.storage import init_db
 
 app = FastAPI()
@@ -24,3 +25,4 @@ app.include_router(auth_router)
 app.include_router(webhook_router)
 app.include_router(backfill_router)
 app.include_router(debug_router)
+app.include_router(sync_router)

--- a/app/routes/sync.py
+++ b/app/routes/sync.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.debug import require_debug_key
+from app.sync import fetch_amo_contacts, fetch_google_contacts, dry_run_compare
+
+router = APIRouter(prefix="/sync", tags=["sync"])
+
+
+def _validate_direction(direction: str) -> str:
+    allowed = {"both", "amo-to-google", "google-to-amo"}
+    if direction not in allowed:
+        raise HTTPException(status_code=400, detail="Invalid direction")
+    return direction
+
+
+@router.get("/contacts/dry-run")
+async def contacts_dry_run(
+    limit: int = Query(50, ge=1, le=200),
+    direction: str = Query("both"),
+    _=Depends(require_debug_key),
+) -> dict[str, object]:
+    direction = _validate_direction(direction)
+    try:
+        amo_contacts = await fetch_amo_contacts(limit)
+    except HTTPException as e:
+        raise e
+    except Exception as e:  # pragma: no cover - unexpected
+        raise HTTPException(status_code=502, detail=f"AmoCRM API error: {e}")
+    try:
+        google_contacts = await fetch_google_contacts(limit)
+    except HTTPException as e:
+        raise e
+    except Exception as e:  # pragma: no cover - unexpected
+        raise HTTPException(status_code=502, detail=f"Google API error: {e}")
+    summary = dry_run_compare(amo_contacts, google_contacts, direction)
+    return {"input": {"limit": limit, "direction": direction}, **summary}

--- a/app/sync.py
+++ b/app/sync.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import httpx
+from fastapi import HTTPException
+
+from app import amocrm, google_people
+from app.config import settings
+from app.utils import normalize_email, normalize_phone, unique
+
+
+async def fetch_amo_contacts(limit: int) -> List[Dict[str, Any]]:
+    token = settings.amo_long_lived_token
+    base_url = settings.amo_base_url.rstrip("/")
+    if not token or not base_url:
+        raise HTTPException(status_code=500, detail="AmoCRM settings missing")
+    url = f"{base_url}/api/v4/contacts"
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"limit": limit}
+    async with httpx.AsyncClient(timeout=20) as client:
+        resp = await client.get(url, headers=headers, params=params)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail=f"AmoCRM API error: {resp.text}")
+    data = resp.json().get("_embedded", {}).get("contacts", [])
+    items: List[Dict[str, Any]] = []
+    for c in data:
+        parsed = amocrm.extract_name_and_fields(c)
+        items.append(
+            {
+                "id": c.get("id"),
+                "name": parsed["name"],
+                "emails": parsed["emails"],
+                "phones": parsed["phones"],
+            }
+        )
+    return items
+
+
+async def fetch_google_contacts(limit: int) -> List[Dict[str, Any]]:
+    token = await google_people.get_access_token()
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {
+        "personFields": "names,emailAddresses,phoneNumbers,metadata",
+        "pageSize": limit,
+    }
+    url = "https://people.googleapis.com/v1/people/me/connections"
+    async with httpx.AsyncClient(timeout=20) as client:
+        resp = await client.get(url, params=params, headers=headers)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail=f"Google API error: {resp.text}")
+    data = resp.json().get("connections", [])
+    items: List[Dict[str, Any]] = []
+    for person in data:
+        names = person.get("names", [])
+        emails = [e.get("value") for e in person.get("emailAddresses", []) if e.get("value")]
+        phones = [p.get("value") for p in person.get("phoneNumbers", []) if p.get("value")]
+        items.append(
+            {
+                "resourceName": person.get("resourceName"),
+                "name": names[0].get("displayName") if names else "",
+                "emails": emails,
+                "phones": phones,
+            }
+        )
+    return items
+
+
+def _prepare_contacts(contacts: List[Dict[str, Any]], id_key: str) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    with_keys: List[Dict[str, Any]] = []
+    without_keys: List[Dict[str, Any]] = []
+    for c in contacts:
+        emails = unique([normalize_email(e) for e in c.get("emails", []) if e])
+        phones = unique([normalize_phone(p) for p in c.get("phones", []) if p])
+        if emails or phones:
+            c = {id_key: c.get(id_key), "name": c.get("name") or "", "emails": emails, "phones": phones}
+            with_keys.append(c)
+        else:
+            without_keys.append(c)
+    return with_keys, without_keys
+
+
+def dry_run_compare(
+    amo_contacts: List[Dict[str, Any]],
+    google_contacts: List[Dict[str, Any]],
+    direction: str,
+) -> Dict[str, Any]:
+    amo_with_keys, amo_no_keys = _prepare_contacts(amo_contacts, "id")
+    google_with_keys, google_no_keys = _prepare_contacts(google_contacts, "resourceName")
+
+    amo_map: Dict[str, Dict[str, Any]] = {}
+    for contact in amo_with_keys:
+        for key in contact["emails"] + contact["phones"]:
+            amo_map.setdefault(key, contact)
+
+    google_map: Dict[str, Dict[str, Any]] = {}
+    for contact in google_with_keys:
+        for key in contact["emails"] + contact["phones"]:
+            google_map.setdefault(key, contact)
+
+    matched_google: set[str] = set()
+    pairs: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+    amo_only: List[Dict[str, Any]] = []
+    for amo_c in amo_with_keys:
+        counterpart = None
+        keys = amo_c["emails"] + amo_c["phones"]
+        for k in keys:
+            g = google_map.get(k)
+            if g and g["resourceName"] not in matched_google:
+                counterpart = g
+                break
+        if counterpart:
+            pairs.append((amo_c, counterpart))
+            matched_google.add(counterpart["resourceName"])
+        else:
+            amo_only.append(amo_c)
+
+    google_only = [c for c in google_with_keys if c["resourceName"] not in matched_google]
+
+    def _pair_diff(amo_c: Dict[str, Any], g_c: Dict[str, Any]) -> Dict[str, Any]:
+        amo_emails = set(amo_c["emails"])
+        g_emails = set(g_c["emails"])
+        amo_phones = set(amo_c["phones"])
+        g_phones = set(g_c["phones"])
+        return {
+            "name_changed": (amo_c.get("name") or "") != (g_c.get("name") or ""),
+            "missing_emails": list(amo_emails - g_emails),
+            "missing_phones": list(amo_phones - g_phones),
+            "extra_emails": list(g_emails - amo_emails),
+            "extra_phones": list(g_phones - amo_phones),
+        }
+
+    updates_preview = []
+    amo_to_google_updates = 0
+    google_to_amo_updates = 0
+    for amo_c, g_c in pairs:
+        diff = _pair_diff(amo_c, g_c)
+        if diff["name_changed"] or diff["missing_emails"] or diff["missing_phones"]:
+            amo_to_google_updates += 1
+        if diff["name_changed"] or diff["extra_emails"] or diff["extra_phones"]:
+            google_to_amo_updates += 1
+        if (
+            diff["name_changed"]
+            or diff["missing_emails"]
+            or diff["missing_phones"]
+            or diff["extra_emails"]
+            or diff["extra_phones"]
+        ) and len(updates_preview) < 5:
+            updates_preview.append(
+                {
+                    "amo": amo_c,
+                    "google": g_c,
+                    "diff": {
+                        "name_changed": diff["name_changed"],
+                        "missing_emails": diff["missing_emails"],
+                        "missing_phones": diff["missing_phones"],
+                    },
+                }
+            )
+
+    result = {
+        "amo": {
+            "fetched": len(amo_contacts),
+            "with_keys": len(amo_with_keys),
+            "skipped_no_keys": len(amo_no_keys),
+        },
+        "google": {
+            "fetched": len(google_contacts),
+            "with_keys": len(google_with_keys),
+            "skipped_no_keys": len(google_no_keys),
+        },
+        "match": {
+            "pairs": len(pairs),
+            "amo_only": len(amo_only),
+            "google_only": len(google_only),
+        },
+        "actions": {
+            "amo_to_google": {
+                "create": len(amo_only) if direction in ("both", "amo-to-google") else 0,
+                "update": amo_to_google_updates if direction in ("both", "amo-to-google") else 0,
+            },
+            "google_to_amo": {
+                "create": len(google_only) if direction in ("both", "google-to-amo") else 0,
+                "update": google_to_amo_updates if direction in ("both", "google-to-amo") else 0,
+            },
+        },
+        "samples": {
+            "amo_only": amo_only[:5],
+            "google_only": google_only[:5],
+            "updates_preview": updates_preview[:5],
+        },
+    }
+    return result

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,23 @@
+from app.sync import dry_run_compare
+
+
+def test_dry_run_compare():
+    amo_contacts = [
+        {"id": 1, "name": "Name1", "emails": ["A@ex.com"], "phones": ["+111"]},
+        {"id": 2, "name": "Name2", "emails": [], "phones": ["+222"]},
+        {"id": 3, "name": "NoKey", "emails": [], "phones": []},
+    ]
+    google_contacts = [
+        {"resourceName": "people/1", "name": "Other", "emails": ["a@ex.com"], "phones": []},
+        {"resourceName": "people/2", "name": "G2", "emails": [], "phones": ["+333"]},
+        {"resourceName": "people/3", "name": "Dup", "emails": ["a@ex.com"], "phones": []},
+        {"resourceName": "people/4", "name": "NoKey", "emails": [], "phones": []},
+    ]
+    result = dry_run_compare(amo_contacts, google_contacts, "both")
+    assert result["amo"] == {"fetched": 3, "with_keys": 2, "skipped_no_keys": 1}
+    assert result["google"] == {"fetched": 4, "with_keys": 3, "skipped_no_keys": 1}
+    assert result["match"] == {"pairs": 1, "amo_only": 1, "google_only": 2}
+    assert result["actions"]["amo_to_google"]["create"] == 1
+    assert result["actions"]["amo_to_google"]["update"] == 1
+    assert result["actions"]["google_to_amo"]["create"] == 2
+    assert result["actions"]["google_to_amo"]["update"] == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,11 @@ from app.utils import normalize_phone, normalize_email, unique, is_valid_email
 
 
 def test_normalize_phone():
-    assert normalize_phone("8 (999) 111-22-33").startswith("+")
+    assert normalize_phone("8 (999) 111-22-33") == "+79991112233"
 
 
 def test_normalize_email_and_validation():
-    email = "USER@Example.Com"
+    email = "  USER@Example.Com "
     normalized = normalize_email(email)
     assert normalized == "user@example.com"
     assert is_valid_email(normalized)


### PR DESCRIPTION
## Summary
- add `/sync/contacts/dry-run` endpoint protected by debug secret
- implement contact fetching and comparison utilities
- extend utils tests and add dry-run comparison test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c733600b9883278136e8705a779209