### PR TITLE
Add guarded debug endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,19 @@ Visit `/auth/google/start` and `/auth/amocrm/start` to complete OAuth flows.
 pytest
 ```
 
-## Diagnostics
+## Debug endpoints
 
-Set a shared secret in `DEBUG_SECRET` (e.g. in Render service settings) to enable read-only diagnostic endpoints. These endpoints perform no writes and can be removed or disabled in production if desired.
+Set the `DEBUG_SECRET` environment variable to enable read-only diagnostic routes under `/debug`. Each request must include header `X-Debug-Secret` with the same value.
 
-Example cURL calls:
+Available endpoints:
+
+- `GET /debug/ping` → `{"status":"ok"}`
+- `GET /debug/db` → database dialect and ping status
+- `GET /debug/google` → whether a Google token exists in DB
+- `GET /debug/amo` → whether an AmoCRM token exists and base URL configured
+
+Example:
 
 ```bash
-curl "http://localhost:8000/debug/google/ping?key=$DEBUG_SECRET"
-curl "http://localhost:8000/debug/google/contacts?limit=3&key=$DEBUG_SECRET"
-curl "http://localhost:8000/debug/amo/ping?key=$DEBUG_SECRET"
-curl "http://localhost:8000/debug/db/token?key=$DEBUG_SECRET"
+curl -H "X-Debug-Secret: $DEBUG_SECRET" http://localhost:8000/debug/ping
 ```

--- a/app/debug.py
+++ b/app/debug.py
@@ -1,133 +1,55 @@
 from __future__ import annotations
 
-from typing import Any, List
-
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Header, Query
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy import text
 
 from app.config import settings
-from app.storage import Token, get_session, get_token
+from app.storage import get_engine, get_session, get_token
 
-router = APIRouter(prefix="/debug", tags=["debug"])
+router = APIRouter()
 
 
-def require_debug_key(
-    x_debug_secret: str | None = Header(default=None, alias="X-Debug-Secret"),
-    key: str | None = Query(None),
-) -> None:
+def require_debug_secret(x_debug_secret: str | None = Header(None, alias="X-Debug-Secret")) -> None:
     secret = settings.debug_secret
-    if not secret:
-        raise HTTPException(status_code=500, detail="DEBUG_SECRET is not set")
-    provided = x_debug_secret or key
-    if provided != secret:
-        raise HTTPException(status_code=403, detail="Forbidden")
+    if not secret or x_debug_secret != secret:
+        raise HTTPException(status_code=401, detail="invalid debug secret")
 
 
-async def _refresh_google_access_token(refresh_token: str) -> str:
-    data = {
-        "client_id": settings.google_client_id,
-        "client_secret": settings.google_client_secret,
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-    }
-    async with httpx.AsyncClient(timeout=20) as client:
-        resp = await client.post("https://oauth2.googleapis.com/token", data=data)
-    if resp.status_code != 200:
-        raise HTTPException(status_code=502, detail=resp.text)
-    return resp.json().get("access_token", "")
+@router.get("/ping")
+def debug_ping(_=Depends(require_debug_secret)) -> dict[str, str]:
+    return {"status": "ok"}
 
 
-async def _get_google_access_token() -> str:
+@router.get("/db")
+def debug_db(_=Depends(require_debug_secret)) -> dict[str, object]:
+    engine = get_engine()
+    ok = True
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception:
+        ok = False
+    return {"dialect": engine.dialect.name, "ok": ok}
+
+
+@router.get("/google")
+def debug_google(_=Depends(require_debug_secret)) -> dict[str, bool]:
     session = get_session()
-    token = get_token(session, "google")
-    session.close()
-    if not token or not token.refresh_token:
-        raise HTTPException(status_code=500, detail="Google token missing")
-    return await _refresh_google_access_token(token.refresh_token)
+    try:
+        token = get_token(session, "google")
+        return {"has_token": bool(token)}
+    finally:
+        session.close()
 
 
-@router.get("/google/ping")
-async def google_ping(_=Depends(require_debug_key)) -> dict[str, Any]:
-    access_token = await _get_google_access_token()
-    headers = {"Authorization": f"Bearer {access_token}"}
-    url = "https://people.googleapis.com/v1/people/me"
-    params = {"personFields": "names,emailAddresses"}
-    async with httpx.AsyncClient(timeout=20) as client:
-        resp = await client.get(url, params=params, headers=headers)
-    if resp.status_code != 200:
-        raise HTTPException(status_code=502, detail=resp.text)
-    data = resp.json()
-    names = data.get("names", [])
-    emails = data.get("emailAddresses", [])
-    name = names[0].get("displayName") if names else None
-    email = emails[0].get("value") if emails else None
-    return {"ok": True, "name": name, "email": email}
-
-
-@router.get("/google/contacts")
-async def google_contacts(limit: int = 10, _=Depends(require_debug_key)) -> dict[str, Any]:
-    access_token = await _get_google_access_token()
-    headers = {"Authorization": f"Bearer {access_token}"}
-    limit = max(1, min(limit, 50))
-    params = {
-        "pageSize": limit,
-        "personFields": "names,emailAddresses",
-        "sortOrder": "FIRST_NAME_ASCENDING",
-    }
-    url = "https://people.googleapis.com/v1/people/me/connections"
-    async with httpx.AsyncClient(timeout=20) as client:
-        resp = await client.get(url, params=params, headers=headers)
-    if resp.status_code != 200:
-        raise HTTPException(status_code=502, detail=resp.text)
-    data = resp.json()
-    items: List[dict[str, Any]] = []
-    for person in data.get("connections", []):
-        names = person.get("names", [])
-        emails = person.get("emailAddresses", [])
-        items.append(
-            {
-                "resourceName": person.get("resourceName"),
-                "name": names[0].get("displayName") if names else None,
-                "email": emails[0].get("value") if emails else None,
-            }
-        )
-    return {"ok": True, "count": len(items), "items": items}
-
-
-@router.get("/amo/ping")
-async def amo_ping(_=Depends(require_debug_key)) -> dict[str, Any]:
-    base_url = settings.amo_base_url.rstrip("/")
-    token = settings.amo_long_lived_token
-    if not base_url or not token:
-        raise HTTPException(status_code=500, detail="AMO_BASE_URL or AMO_LONG_LIVED_TOKEN is not set")
-    headers = {"Authorization": f"Bearer {token}"}
-    url = f"{base_url}/api/v4/account"
-    async with httpx.AsyncClient(timeout=20) as client:
-        resp = await client.get(url, headers=headers)
-    if resp.status_code != 200:
-        raise HTTPException(status_code=502, detail=resp.text)
-    data = resp.json()
-    return {
-        "ok": True,
-        "id": data.get("id"),
-        "name": data.get("name"),
-        "subdomain": data.get("subdomain"),
-    }
-
-
-@router.get("/db/token")
-async def db_token(_=Depends(require_debug_key)) -> dict[str, Any]:
+@router.get("/amo")
+def debug_amo(_=Depends(require_debug_secret)) -> dict[str, bool]:
     session = get_session()
-    tokens = session.execute(select(Token)).scalars().all()
-    session.close()
-    items = [
-        {
-            "system": t.system,
-            "has_refresh": bool(t.refresh_token),
-            "expires_at": t.expiry.isoformat() if t.expiry else None,
-            "updated_at": t.updated_at.isoformat() if t.updated_at else None,
+    try:
+        token = get_token(session, "amocrm")
+        return {
+            "has_token": bool(token),
+            "has_base_url": bool(settings.amo_base_url),
         }
-        for t in tokens
-    ]
-    return {"ok": True, "tokens": items}
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,28 +1,40 @@
+import logging
+
 from fastapi import FastAPI
 
 from app.auth import router as auth_router
-from app.webhooks import router as webhook_router
 from app.backfill import router as backfill_router
+from app.config import settings
 from app.debug import router as debug_router
 from app.routes.sync import router as sync_router
 from app.storage import init_db
+from app.webhooks import router as webhook_router
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def _startup() -> None:
-    # Привязать engine и создать таблицы при первом запуске
-    init_db()
+logger = logging.getLogger(__name__)
 
 
-@app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.on_event("startup")
+    def _startup() -> None:
+        init_db()
+        if settings.debug_secret:
+            logger.info("Debug router enabled on /debug")
+        else:
+            logger.info("Debug router disabled")
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(auth_router)
+    app.include_router(webhook_router)
+    app.include_router(backfill_router)
+    if settings.debug_secret:
+        app.include_router(debug_router, prefix="/debug")
+    app.include_router(sync_router)
+    return app
 
 
-app.include_router(auth_router)
-app.include_router(webhook_router)
-app.include_router(backfill_router)
-app.include_router(debug_router)
-app.include_router(sync_router)
+app = create_app()

--- a/app/routes/sync.py
+++ b/app/routes/sync.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from app.debug import require_debug_key
-from app.sync import fetch_amo_contacts, fetch_google_contacts, dry_run_compare
+from app.debug import require_debug_secret
+from app.sync import dry_run_compare, fetch_amo_contacts, fetch_google_contacts
 
 router = APIRouter(prefix="/sync", tags=["sync"])
 
@@ -19,7 +19,7 @@ def _validate_direction(direction: str) -> str:
 async def contacts_dry_run(
     limit: int = Query(50, ge=1, le=200),
     direction: str = Query("both"),
-    _=Depends(require_debug_key),
+    _=Depends(require_debug_secret),
 ) -> dict[str, object]:
     direction = _validate_direction(direction)
     try:

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,30 +1,46 @@
+import importlib
+
 from fastapi.testclient import TestClient
 
-from app.config import settings
-from app.main import app
-from app.storage import init_db
+
+def _app_with_secret(monkeypatch, secret: str):
+    from app.config import settings
+    monkeypatch.setattr(settings, "debug_secret", secret)
+    from app.main import create_app
+    return create_app()
 
 
-def test_debug_requires_key(monkeypatch):
-    monkeypatch.setattr(settings, "debug_secret", "s")
+def test_debug_not_mounted_without_secret(monkeypatch):
+    app = _app_with_secret(monkeypatch, "")
     client = TestClient(app)
-    resp = client.get("/debug/db/token")
-    assert resp.status_code == 403
-    resp = client.get("/debug/db/token?key=wrong")
-    assert resp.status_code == 403
+    resp = client.get("/debug/ping")
+    assert resp.status_code == 404
 
 
-def test_debug_missing_secret(monkeypatch):
-    monkeypatch.setattr(settings, "debug_secret", "")
+def test_debug_requires_header(monkeypatch):
+    app = _app_with_secret(monkeypatch, "s")
     client = TestClient(app)
-    resp = client.get("/debug/db/token?key=any")
-    assert resp.status_code == 500
+    resp = client.get("/debug/ping")
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "invalid debug secret"}
 
 
-def test_debug_with_correct_key(monkeypatch):
-    monkeypatch.setattr(settings, "debug_secret", "s")
-    init_db()
+def test_debug_with_header(monkeypatch):
+    app = _app_with_secret(monkeypatch, "s")
     client = TestClient(app)
-    resp = client.get("/debug/db/token?key=s")
+    resp = client.get("/debug/ping", headers={"X-Debug-Secret": "s"})
     assert resp.status_code == 200
-    assert resp.json()["ok"] is True
+    assert resp.json() == {"status": "ok"}
+
+
+def test_debug_ping_env(monkeypatch):
+    monkeypatch.setenv("DEBUG_SECRET", "env")
+    import app.config as config
+    importlib.reload(config)
+    import app.debug as debug
+    importlib.reload(debug)
+    import app.main as main
+    importlib.reload(main)
+    client = TestClient(main.app)
+    resp = client.get("/debug/ping", headers={"X-Debug-Secret": "env"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Conditionally mount /debug router when `DEBUG_SECRET` is set
- Guard debug and dry-run routes with `X-Debug-Secret`
- Provide minimal debug endpoints for ping, DB info, Google and Amo token presence
- Document debug endpoints in README and test behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73a66f78483278dabab659e394d2f