### PR TITLE
Protect debug routes with secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,28 @@ pytest
 
 ## Debug endpoints
 
-Set the `DEBUG_SECRET` environment variable to enable read-only diagnostic routes under `/debug`. Each request must include header `X-Debug-Secret` with the same value.
+Set `DEBUG_SECRET` to enable read‑only diagnostic routes under `/debug`. The value can be provided via environment variable or `.env` file, e.g.:
+
+```bash
+export DEBUG_SECRET=my-secret
+```
+
+Every request to these routes must include header `X-Debug-Secret` with the same value. Missing or invalid secret returns `401 {"detail": "invalid debug secret"}`.
 
 Available endpoints:
 
-- `GET /debug/ping` → `{"status":"ok"}`
-- `GET /debug/db` → database dialect and ping status
-- `GET /debug/google` → whether a Google token exists in DB
-- `GET /debug/amo` → whether an AmoCRM token exists and base URL configured
+| Endpoint | Description |
+| --- | --- |
+| `GET /debug/ping` | `{"status":"ok"}` |
+| `GET /debug/db` | Database dialect and ping success |
+| `GET /debug/google` | Google token status: `has_token`, `expires_at`, `will_refresh` |
+| `GET /debug/amo` | AmoCRM token status and configured base URL |
 
-Example:
+Examples:
 
 ```bash
 curl -H "X-Debug-Secret: $DEBUG_SECRET" http://localhost:8000/debug/ping
+curl -H "X-Debug-Secret: $DEBUG_SECRET" http://localhost:8000/debug/db
+curl -H "X-Debug-Secret: $DEBUG_SECRET" http://localhost:8000/debug/google
+curl -H "X-Debug-Secret: $DEBUG_SECRET" http://localhost:8000/debug/amo
 ```


### PR DESCRIPTION
## Summary
- secure debug endpoints with `X-Debug-Secret`
- expose DB, Google, and AmoCRM diagnostics under `/debug`
- document debug router configuration and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a6239da08327bdc6952906bb2849