### PR TITLE
Honor dry-run direction in sync summary

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,10 +45,10 @@ def test_dry_run_ok(monkeypatch):
     from app.routes import sync as sync_route
 
     async def fake_fetch_google(limit, since_days=None):  # noqa: ARG001
-        return [{"resourceName": "r1", "name": "g", "emails": [], "phones": []}]
+        return [{"resourceName": "r1", "name": "g", "emails": ["g@ex.com"], "phones": []}]
 
     async def fake_fetch_amo(limit):  # noqa: ARG001
-        return [{"id": 1, "name": "a", "emails": [], "phones": []}]
+        return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
 
     monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
     monkeypatch.setattr(sync_route, "fetch_amo_contacts", fake_fetch_amo)
@@ -59,5 +59,46 @@ def test_dry_run_ok(monkeypatch):
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "ok"
-        assert data["counts"] == {"google": 1, "amo": 1}
+        assert data["summary"]["actions"]["amo_to_google"]["create"] == 1
+        assert data["summary"]["actions"]["google_to_amo"]["create"] == 1
+        assert len(data["samples"]["amo_only"]) == 1
+        assert len(data["samples"]["google_only"]) == 1
+
+
+def test_dry_run_direction_amo(monkeypatch):
+    from app.routes import sync as sync_route
+
+    async def fake_fetch_amo(limit):  # noqa: ARG001
+        return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
+
+    monkeypatch.setattr(sync_route, "fetch_amo_contacts", fake_fetch_amo)
+
+    app = create(monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sync/contacts/dry-run?limit=10&direction=amo")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "amo_to_google" in data["summary"]["actions"]
+        assert "google_to_amo" not in data["summary"]["actions"]
+        assert len(data["samples"]["amo_only"]) == 1
+        assert "google_only" not in data["samples"]
+
+
+def test_dry_run_direction_google(monkeypatch):
+    from app.routes import sync as sync_route
+
+    async def fake_fetch_google(limit, since_days=None):  # noqa: ARG001
+        return [{"resourceName": "r1", "name": "g", "emails": ["g@ex.com"], "phones": []}]
+
+    monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
+
+    app = create(monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sync/contacts/dry-run?limit=10&direction=google")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "google_to_amo" in data["summary"]["actions"]
+        assert "amo_to_google" not in data["summary"]["actions"]
+        assert len(data["samples"]["google_only"]) == 1
+        assert "amo_only" not in data["samples"]
 


### PR DESCRIPTION
## Summary
- Pass user-selected direction to `dry_run_compare`
- Show summary actions and samples only for the requested sync direction
- Add API tests covering amo-only and google-only dry run results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7cea44994832789ff202d0c5e4976