### PR TITLE
refactor: remove redundant HTTPException re-raise

### DIFF
--- a/app/routes/sync.py
+++ b/app/routes/sync.py
@@ -25,8 +25,6 @@ async def contacts_dry_run(
     direction = _validate_direction(direction)
     try:
         amo_contacts = await fetch_amo_contacts(limit) if direction in {"both", "amo"} else []
-    except HTTPException as e:
-        raise e
     except Exception as e:  # pragma: no cover - unexpected
         raise HTTPException(status_code=502, detail=f"AmoCRM API error: {e}")
     try:


### PR DESCRIPTION
## Summary
- simplify sync route error handling by letting HTTPExceptions propagate naturally

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ceb1c0a4832799d79e8327ecf781