### PR TITLE
Configure Ruff to skip S101 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+extend-select = ["E", "F", "S"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101"]


### PR DESCRIPTION
## Summary
- add Ruff configuration in `pyproject.toml` to ignore Bandit S101 warnings under the tests folder

## Testing
- `ruff check . --output-format=github` *(fails: E501 line too long, S105 possible hardcoded password)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d3ef5b488327a425f77bce0af0f1