### PR TITLE
fix(amocrm): tolerate missing custom fields

### DIFF
--- a/tests/test_amocrm.py
+++ b/tests/test_amocrm.py
@@ -13,3 +13,27 @@ def test_extract_name_and_fields():
     assert result["name"] == "John Doe"
     assert result["phones"] == ["+123"]
     assert result["emails"] == ["test@example.com"]
+
+
+def test_extract_handles_none_custom_fields():
+    contact = {"name": "John", "custom_fields_values": None}
+    result = extract_name_and_fields(contact)
+    assert result["name"] == "John"
+    assert result["phones"] == []
+    assert result["emails"] == []
+
+
+def test_extract_handles_missing_and_empty_structures():
+    contacts = [
+        {"first_name": "Jane", "last_name": "Doe"},
+        {"name": "A", "custom_fields_values": []},
+        {"name": "B", "custom_fields_values": [{}]},
+        {"name": "C", "custom_fields_values": [{"field_code": "PHONE"}]},
+        {"name": "D", "custom_fields_values": [{"values": []}]},
+        {"name": "E", "custom_fields_values": [{"field_code": "EMAIL", "values": [{}]}]},
+    ]
+    for c in contacts:
+        result = extract_name_and_fields(c)
+        assert result["phones"] == []
+        assert result["emails"] == []
+    assert extract_name_and_fields(contacts[0])["name"] == "Jane Doe"


### PR DESCRIPTION
## Summary
- avoid crashes when AmoCRM contacts have missing or malformed `custom_fields_values`
- add regression tests for parsing and apply endpoint

## Testing
- `ruff check app tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7dcd8559883278fc76a8497e7650c