### PR TITLE
fix(sync): improve dry-run matching via Google search

### DIFF
--- a/app/routes/sync.py
+++ b/app/routes/sync.py
@@ -34,8 +34,11 @@ async def contacts_dry_run(
     except Exception as e:  # pragma: no cover - unexpected
         raise HTTPException(status_code=502, detail=f"AmoCRM API error: {e}")
     try:
-        google_contacts = (
-            await fetch_google_contacts(limit, since_days) if direction in {"both", "google"} else []
+        google_contacts, counters = await fetch_google_contacts(
+            limit,
+            since_days,
+            amo_contacts if direction in {"both", "amo"} else None,
+            list_existing=direction in {"both", "google"},
         )
     except GoogleAuthError:
         from fastapi.responses import JSONResponse
@@ -76,6 +79,7 @@ async def contacts_dry_run(
             "actions": actions,
         },
         "samples": samples,
+        "debug": {"counters": counters},
     }
 
 


### PR DESCRIPTION
## Summary
- expand Google People client with pagination and search helpers
- enhance dry-run to search Google by amo keys, respect since_days and report debug counters
- test updated dry-run logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7e676833483278b0beca71a4fdcdb