### PR TITLE
chore(sync): normalize contacts and broaden tests

### DIFF
--- a/app/amocrm.py
+++ b/app/amocrm.py
@@ -4,6 +4,7 @@ import httpx
 
 from app.config import settings
 from app.storage import get_session, get_token
+from app.utils import normalize_email, normalize_phone
 
 
 AMO_HEADERS = {"Content-Type": "application/json"}
@@ -54,7 +55,7 @@ def extract_name_and_fields(contact: Dict[str, Any]) -> Dict[str, Any]:
                 continue
             value = v.get("value")
             if code == "PHONE" and value:
-                phones.append(value)
+                phones.append(normalize_phone(value))
             elif code == "EMAIL" and value:
-                emails.append(value)
+                emails.append(normalize_email(value))
     return {"name": name, "phones": phones, "emails": emails}

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,12 +3,18 @@ from typing import List
 
 
 def normalize_phone(phone: str) -> str:
+    """Return a unified ``+<digits>`` phone representation.
+
+    ``normalize_phone`` strips all non-digit characters, converts a Russian
+    leading ``8`` to ``+7`` and handles European ``00`` prefixes.
+    """
+
     digits = re.sub(r"\D", "", phone)
-    if digits.startswith("8"):
+    if digits.startswith("00"):
+        digits = digits[2:]
+    if digits.startswith("8") and len(digits) == 11:
         digits = "7" + digits[1:]
-    if not digits.startswith("+"):
-        digits = "+" + digits
-    return digits
+    return "+" + digits
 
 
 def unique(sequence: List[str]) -> List[str]:

--- a/tests/test_amocrm.py
+++ b/tests/test_amocrm.py
@@ -37,3 +37,16 @@ def test_extract_handles_missing_and_empty_structures():
         assert result["phones"] == []
         assert result["emails"] == []
     assert extract_name_and_fields(contacts[0])["name"] == "Jane Doe"
+
+
+def test_extract_normalizes_values() -> None:
+    contact = {
+        "name": "John",
+        "custom_fields_values": [
+            {"field_code": "PHONE", "values": [{"value": "8 (999) 111-22-33"}]},
+            {"field_code": "EMAIL", "values": [{"value": " User@MAIL.com "}]},
+        ],
+    }
+    result = extract_name_and_fields(contact)
+    assert result["phones"] == ["+79991112233"]
+    assert result["emails"] == ["user@mail.com"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,35 @@
-from app.utils import normalize_phone, normalize_email, unique, is_valid_email
+import pytest
+
+from app.utils import is_valid_email, normalize_email, normalize_phone, unique
 
 
-def test_normalize_phone():
-    assert normalize_phone("8 (999) 111-22-33") == "+79991112233"
+@pytest.mark.parametrize(
+    "raw, normalized",
+    [
+        ("+375 (29) 123-45-67", "+375291234567"),
+        ("8 (999) 111-22-33", "+79991112233"),
+        ("0049 89 1234567", "+49891234567"),
+        ("+44 20 7946-0958", "+442079460958"),
+    ],
+)
+def test_normalize_phone_formats(raw: str, normalized: str) -> None:
+    assert normalize_phone(raw) == normalized
 
 
-def test_normalize_email_and_validation():
-    email = "  USER@Example.Com "
-    normalized = normalize_email(email)
-    assert normalized == "user@example.com"
+@pytest.mark.parametrize(
+    "raw, normalized",
+    [
+        ("User@MAIL.com ", "user@mail.com"),
+        (" test.user+tag@GMail.COM", "test.user+tag@gmail.com"),
+        ("\tPerson@Example.ru\n", "person@example.ru"),
+        ("CUSTOMER@tut.by", "customer@tut.by"),
+    ],
+)
+def test_normalize_email_formats(raw: str, normalized: str) -> None:
+    assert normalize_email(raw) == normalized
     assert is_valid_email(normalized)
 
 
-def test_unique():
+def test_unique() -> None:
     data = ["a", "b", "a"]
     assert unique(data) == ["a", "b"]


### PR DESCRIPTION
## Summary
- normalize phone/email values when extracting AmoCRM contact fields
- improve phone normalization to handle `00` prefixes and document behavior
- expand unit tests for diverse phone/email formats and verify AmoCRM parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7e69520b0832793f7644c61734afd