### PR TITLE
fix(sync): handle timezone-aware comparisons for since_days

### DIFF
--- a/tests/test_google_people.py
+++ b/tests/test_google_people.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta, timezone
+
+from app.google_people import _parse_rfc3339, _parse_update_time
+
+
+def test_parse_rfc3339():
+    dt_z = _parse_rfc3339("2024-01-02T03:04:05Z")
+    dt_offset = _parse_rfc3339("2024-01-02T03:04:05+03:00")
+    assert dt_z.tzinfo is not None
+    assert dt_offset.tzinfo is not None
+
+
+def test_filter_by_since_days():
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=1)
+    recent = (cutoff + timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+    old = (cutoff - timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+    p_recent = {"metadata": {"sources": [{"updateTime": recent}]}}
+    p_old = {"metadata": {"sources": [{"updateTime": old}]}}
+    recent_dt = _parse_update_time(p_recent)
+    old_dt = _parse_update_time(p_old)
+    assert recent_dt and recent_dt >= cutoff
+    assert old_dt and old_dt < cutoff


### PR DESCRIPTION
## Summary
- ensure UTC-aware timestamps when filtering by `since_days`
- parse Google RFC3339 update times as aware datetimes
- add tests for RFC3339 parsing, date filtering and dry-run with `since_days`

## Testing
- `python -m ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7f71c190883279694d73b08ec035c