### PR TITLE
Fix webhook signature verification

### DIFF
--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -1,8 +1,9 @@
 import hashlib
 import hmac
+import json
 from typing import Any, Dict, List
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Request
 
 from app.amocrm import extract_name_and_fields, get_contact
 from app.google_people import upsert_contact_by_external_id
@@ -23,10 +24,12 @@ def verify_signature(body: bytes, signature: str | None) -> bool:
 
 
 @router.post("/webhooks/amocrm")
-async def handle_webhook(payload: Dict[str, Any], x_signature: str | None = Header(None)):
-    body_bytes = str(payload).encode()
+async def handle_webhook(request: Request, x_signature: str | None = Header(None)):
+    body_bytes = await request.body()
     if not verify_signature(body_bytes, x_signature):
         raise HTTPException(status_code=401, detail="Invalid signature")
+
+    payload: Dict[str, Any] = json.loads(body_bytes)
 
     contact_ids: List[int] = []
     events = payload.get("contacts", {}).get("update", [])

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,9 +1,17 @@
+import hashlib
+import hmac
+import json
+
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app import webhooks
+from app.config import settings
 
 
 def test_webhook(monkeypatch):
+    webhooks.processed_events.clear()
+
     async def fake_get_contact(cid):
         return {"name": "John", "custom_fields_values": []}
 
@@ -22,3 +30,36 @@ def test_webhook(monkeypatch):
     resp = client.post("/webhooks/amocrm", json=payload)
     assert resp.status_code == 200
     assert resp.json()["synced"][0]["google_resource_name"] == "people/1"
+
+
+def test_webhook_valid_signature(monkeypatch):
+    webhooks.processed_events.clear()
+
+    async def fake_get_contact(cid):
+        return {"name": "John", "custom_fields_values": []}
+
+    async def fake_upsert(amo_contact_id, data):
+        return {"resourceName": f"people/{amo_contact_id}"}
+
+    def fake_save_link(session, cid, rn):
+        return None
+
+    monkeypatch.setattr("app.webhooks.get_contact", fake_get_contact)
+    monkeypatch.setattr("app.webhooks.upsert_contact_by_external_id", fake_upsert)
+    monkeypatch.setattr("app.webhooks.save_link", fake_save_link)
+
+    secret = "supersecret"
+    monkeypatch.setattr(settings, "webhook_shared_secret", secret)
+
+    client = TestClient(app)
+    payload = {"event_id": "2", "contacts": {"update": [{"id": 2}]}}
+    payload_bytes = json.dumps(payload).encode()
+    signature = hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+
+    resp = client.post(
+        "/webhooks/amocrm",
+        data=payload_bytes,
+        headers={"Content-Type": "application/json", "X-Signature": signature},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["synced"][0]["google_resource_name"] == "people/2"


### PR DESCRIPTION
## Summary
- read webhook request body bytes directly from the FastAPI Request before parsing JSON
- compute the HMAC signature using the original request payload bytes and reuse them for JSON parsing
- add a regression test to confirm requests signed with the shared secret are accepted

## Testing
- `pytest tests/test_webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_68cdbf756c2883279d8d52752e74b9dc