### PR TITLE
Improve debug and sync diagnostics with Google API backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,61 @@ Available endpoints:
 | --- | --- |
 | `GET /debug/db` | Database connectivity and number of stored tokens |
 | `GET /debug/google` | Google token status: `has_token`, `expires_at`, `scopes` |
-| `GET /debug/amo` | AmoCRM base URL and whether a token is stored |
+| `GET /debug/amo` | AmoCRM configuration: `base_url`, `auth_mode`, `is_ready` |
+| `GET /debug/ping-google` | Quick Google People API probe with latency and retry hints |
 
 Example:
 
 ```bash
 curl -H "X-Debug-Secret: $DEBUG_SECRET" http://localhost:8000/debug/db
 ```
+
+`GET /debug/ping-google` performs a lightweight request against
+`people/me`. The response contains `ok`, `latency_ms` and `retry_after`
+fields. When the service is rate limited it returns HTTP 200 with
+`{"ok": false, "error": "rate_limited", "retry_after": <seconds>}`.
+A missing/expired token yields HTTP 401 with the usual
+`{"detail": "Google auth required", "auth_url": "/auth/google/start"}`
+payload.
+
+## Sync API
+
+### `/sync/contacts/dry-run`
+
+Parameters:
+
+* `limit` – maximum number of contacts to scan (default 50, hard capped to 20
+  when `direction=both`; the response includes `limit_clamped: true` when a
+  clamp happens).
+* `direction` – `both` (default), `amo` or `google`.
+* `since_days` – optional AmoCRM/Google filter by last update.
+* `mode` – `fast` (default) fetches only the first Google People page; use
+  `full` for exhaustive pagination when troubleshooting.
+
+The response now contains diagnostic fields to aid performance tuning:
+`duration_ms`, `google_requests`, `amo_requests`, `retries`, `rate_limit_hits`,
+`pages_google`, `pages_amo`, as well as `limit_clamped` and `mode` echo.
+
+### `/sync/contacts/apply`
+
+Only `direction=to_google` is supported today. The response includes the same
+diagnostic counters (`duration_ms`, `google_requests`, `amo_requests`,
+`retries`, `rate_limit_hits`, `pages_*`) alongside the existing summary.
+
+For safe manual testing prefer small batches and pauses between runs, e.g.:
+
+```bash
+http \
+  :8000/sync/contacts/dry-run \
+  limit==10 direction==both mode==fast
+
+sleep 5
+
+http \
+  :8000/sync/contacts/apply \
+  limit==5 since_days==14 direction==to_google confirm==1 \
+  "X-Debug-Secret:$DEBUG_SECRET"
+```
+
+Run `dry-run` in `fast` mode first; switch to `mode=full` only when the quick
+preview suggests mismatches that require deeper investigation.

--- a/app/debug.py
+++ b/app/debug.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 
 from app.config import settings
+from app.google_auth import GoogleAuthError
+from app.google_people import GOOGLE_API_BASE, get_access_token
 from app.storage import Token, get_session, get_token
 
 router = APIRouter()
@@ -44,6 +52,100 @@ def debug_amo(_=Depends(require_debug_secret)) -> dict[str, object]:
     session = get_session()
     try:
         token = get_token(session, "amocrm")
-        return {"base_url": settings.amo_base_url, "has_token": bool(token)}
+        auth_mode = "none"
+        is_ready = False
+        if token and token.access_token:
+            auth_mode = "oauth"
+            if not token.expiry:
+                is_ready = True
+            else:
+                now = datetime.utcnow()
+                is_ready = token.expiry > now
+        elif settings.amo_long_lived_token:
+            auth_mode = "api_key"
+            is_ready = True
+        return {
+            "base_url": settings.amo_base_url,
+            "auth_mode": auth_mode,
+            "is_ready": is_ready,
+        }
     finally:
         session.close()
+
+
+def _parse_retry_after(resp: httpx.Response) -> int | None:
+    header = resp.headers.get("Retry-After")
+    if header:
+        try:
+            return int(float(header))
+        except ValueError:
+            parsed = parsedate_to_datetime(header)
+            if parsed is not None:
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                delta = parsed - datetime.now(timezone.utc)
+                return int(delta.total_seconds()) if delta.total_seconds() > 0 else 0
+    reset_header = resp.headers.get("X-RateLimit-Reset")
+    if reset_header:
+        try:
+            reset_ts = float(reset_header)
+            wait = int(reset_ts - time.time())
+            return wait if wait > 0 else 0
+        except ValueError:
+            return None
+    return None
+
+
+@router.get("/ping-google")
+async def ping_google(_=Depends(require_debug_secret)):
+    start = time.perf_counter()
+    try:
+        token = await get_access_token()
+    except GoogleAuthError:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Google auth required", "auth_url": "/auth/google/start"},
+        )
+
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"personFields": "names"}
+    url = f"{GOOGLE_API_BASE}/people/me"
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            resp = await client.get(url, headers=headers, params=params)
+    except httpx.RequestError as exc:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        return {"ok": False, "latency_ms": latency_ms, "retry_after": None, "error": str(exc)}
+
+    latency_ms = int((time.perf_counter() - start) * 1000)
+
+    if resp.status_code == 401:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Google auth required", "auth_url": "/auth/google/start"},
+        )
+
+    if resp.status_code == 429:
+        retry_after = _parse_retry_after(resp)
+        return {
+            "ok": False,
+            "latency_ms": latency_ms,
+            "retry_after": retry_after,
+            "error": "rate_limited",
+        }
+
+    if resp.status_code != 200:
+        detail = None
+        try:
+            detail = resp.json()
+        except ValueError:
+            detail = resp.text
+        return {
+            "ok": False,
+            "latency_ms": latency_ms,
+            "retry_after": None,
+            "error": detail,
+            "status": resp.status_code,
+        }
+
+    return {"ok": True, "latency_ms": latency_ms, "retry_after": None}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ def test_dry_run_no_token(monkeypatch):
     sess.commit()
     sess.close()
 
-    async def fake_fetch_amo(limit):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, stats=None):  # noqa: ARG001
         return []
 
     monkeypatch.setattr(sync_route, "fetch_amo_contacts", fake_fetch_amo)
@@ -46,13 +46,21 @@ def test_dry_run_no_token(monkeypatch):
 def test_dry_run_ok(monkeypatch):
     from app.routes import sync as sync_route
 
-    async def fake_fetch_google(limit, since_days=None, amo_contacts=None, list_existing=True):  # noqa: ARG001
+    async def fake_fetch_google(
+        limit,
+        since_days=None,
+        amo_contacts=None,
+        list_existing=True,
+        *,
+        mode="fast",
+        stats=None,
+    ):  # noqa: ARG001
         return (
             [{"resourceName": "r1", "name": "g", "emails": ["g@ex.com"], "phones": []}],
             {"requests": 1, "considered": 1, "found": 0},
         )
 
-    async def fake_fetch_amo(limit):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, stats=None):  # noqa: ARG001
         return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
 
     monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
@@ -74,10 +82,18 @@ def test_dry_run_ok(monkeypatch):
 def test_dry_run_direction_amo(monkeypatch):
     from app.routes import sync as sync_route
 
-    async def fake_fetch_amo(limit):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, stats=None):  # noqa: ARG001
         return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
 
-    async def fake_fetch_google(limit, since_days=None, amo_contacts=None, list_existing=True):  # noqa: ARG001
+    async def fake_fetch_google(
+        limit,
+        since_days=None,
+        amo_contacts=None,
+        list_existing=True,
+        *,
+        mode="fast",
+        stats=None,
+    ):  # noqa: ARG001
         return ([], {"requests": 0, "considered": 0, "found": 0})
 
     monkeypatch.setattr(sync_route, "fetch_amo_contacts", fake_fetch_amo)
@@ -99,13 +115,21 @@ def test_dry_run_direction_amo(monkeypatch):
 def test_dry_run_direction_google(monkeypatch):
     from app.routes import sync as sync_route
 
-    async def fake_fetch_google(limit, since_days=None, amo_contacts=None, list_existing=True):  # noqa: ARG001
+    async def fake_fetch_google(
+        limit,
+        since_days=None,
+        amo_contacts=None,
+        list_existing=True,
+        *,
+        mode="fast",
+        stats=None,
+    ):  # noqa: ARG001
         return (
             [{"resourceName": "r1", "name": "g", "emails": ["g@ex.com"], "phones": []}],
             {"requests": 1, "considered": 1, "found": 0},
         )
 
-    async def fake_fetch_amo(limit):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, stats=None):  # noqa: ARG001
         return []
 
     monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
@@ -129,7 +153,7 @@ def test_dry_run_since_days(monkeypatch):
     from app import google_people
     from app.google_people import Contact
 
-    async def fake_list_contacts(limit, since_days=None, counters=None):  # noqa: ARG001
+    async def fake_list_contacts(limit, since_days=None, counters=None, *, fast=False):  # noqa: ARG001
         return [
             Contact(
                 resource_id="r1",
@@ -143,7 +167,7 @@ def test_dry_run_since_days(monkeypatch):
     async def fake_search_contacts(query, counters=None):  # noqa: ARG001
         return []
 
-    async def fake_fetch_amo(limit, since_days=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, stats=None):  # noqa: ARG001
         return []
 
     monkeypatch.setattr(google_people, "list_contacts", fake_list_contacts)
@@ -158,4 +182,37 @@ def test_dry_run_since_days(monkeypatch):
         assert resp.status_code == 200
         data = resp.json()
         assert data["summary"] is not None
+
+
+def test_dry_run_limit_clamped(monkeypatch):
+    from app.routes import sync as sync_route
+
+    async def fake_fetch_google(
+        limit,
+        since_days=None,
+        amo_contacts=None,
+        list_existing=True,
+        *,
+        mode="fast",
+        stats=None,
+    ):  # noqa: ARG001
+        return ([], {"requests": 0, "considered": 0, "found": 0})
+
+    async def fake_fetch_amo(limit, since_days=None, stats=None):  # noqa: ARG001
+        if stats is not None:
+            stats["amo_requests"] = stats.get("amo_requests", 0) + 1
+            stats["pages_amo"] = stats.get("pages_amo", 0) + 1
+        return []
+
+    monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
+    monkeypatch.setattr(sync_route, "fetch_amo_contacts", fake_fetch_amo)
+
+    app = create(monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sync/contacts/dry-run?limit=50&direction=both")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["limit_clamped"] is True
+        assert data["mode"] == "fast"
+        assert data["amo_requests"] == 1
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -17,7 +17,7 @@ def create(monkeypatch, secret: str | None = None):
 def test_apply_upserts(monkeypatch):
     from app import sync as sync_module
 
-    async def fake_fetch_amo(limit, since_days):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days, stats=None):  # noqa: ARG001
         return [
             {"id": 1, "name": "a", "emails": ["a@example.com"], "phones": []},
             {"id": 2, "name": "b", "emails": ["b@example.com"], "phones": []},
@@ -82,7 +82,7 @@ def test_apply_upserts(monkeypatch):
 def test_apply_missing_etag(monkeypatch):
     from app import sync as sync_module
 
-    async def fake_fetch_amo(limit, since_days):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days, stats=None):  # noqa: ARG001
         return [{"id": 1, "name": "a", "emails": ["a@example.com"], "phones": []}]
 
     async def fake_search(key):  # noqa: ARG001
@@ -125,7 +125,7 @@ def test_apply_missing_etag(monkeypatch):
 def test_apply_rate_limited(monkeypatch):
     from app import sync as sync_module
 
-    async def fake_fetch_amo(limit, since_days):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days, stats=None):  # noqa: ARG001
         return [
             {"id": 1, "name": "a", "emails": ["a@example.com"], "phones": []},
             {"id": 2, "name": "b", "emails": ["b@example.com"], "phones": []},
@@ -246,7 +246,7 @@ def test_apply_success_passthrough(monkeypatch):
 def test_apply_skips_none_custom_fields_contacts_no_crash(monkeypatch):
     from app import sync as sync_module
 
-    async def fake_fetch(limit, since_days):  # noqa: ARG001
+    async def fake_fetch(limit, since_days, stats=None):  # noqa: ARG001
         raw = [{"id": 1, "name": "", "custom_fields_values": None}]
         parsed = []
         for c in raw:


### PR DESCRIPTION
## Summary
- add `/debug/ping-google` and enrich `/debug/amo` with auth status reporting
- clamp heavy dry-runs, support `mode=fast`, and include timing/request counters in sync responses
- respect Google People API Retry-After with exponential backoff and propagate metrics from the client layer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cddb62356c8327ae563be58d10aaf2