### PR TITLE
Clamp dry run limit for fast bidirectional sync

### DIFF
--- a/app/routes/sync.py
+++ b/app/routes/sync.py
@@ -40,7 +40,7 @@ async def contacts_dry_run(
 
     effective_limit = limit
     limit_clamped = False
-    if direction == "both" and limit > 20:
+    if direction == "both" and mode == "fast" and limit > 20:
         effective_limit = 20
         limit_clamped = True
 
@@ -202,7 +202,7 @@ async def contacts_dry_run(
                 "actions": actions,
             },
             "samples": samples,
-            "debug": {"counters": counters},
+            "debug": {"counters": counters, "limit": effective_limit},
             "partial": partial,
             "errors": errors,
             "duration_ms": duration_ms,


### PR DESCRIPTION
## Summary
- clamp the dry-run limit to 20 when running fast syncs in both directions
- expose the effective limit inside the debug payload and flag when it was clamped

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce52ac2d0c832785cef27e3141fa35