### PR TITLE
Use contacts-safe People API probe

### DIFF
--- a/app/debug.py
+++ b/app/debug.py
@@ -167,8 +167,8 @@ async def ping_google(_=Depends(require_debug_secret)) -> dict[str, object]:
         session.close()
 
     headers = {"Authorization": f"Bearer {access_token}"}
-    params = {"personFields": "metadata"}
-    url = f"{GOOGLE_API_BASE}/people/me"
+    params = {"personFields": "metadata", "pageSize": 1}
+    url = f"{GOOGLE_API_BASE}/people/me/connections"
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             resp = await client.get(url, headers=headers, params=params)


### PR DESCRIPTION
## Summary
- update the debug Google health probe to call the People connections endpoint that works with the contacts scope
- adjust debug endpoint tests for the new request shape and cover the regression scenario for profile-scope errors

## Testing
- pytest tests/test_debug.py

------
https://chatgpt.com/codex/tasks/task_e_68ce5f35a8b08327938904567449c594