### PR TITLE
Add filters to contacts apply sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Only `direction=to_google` is supported today. The response includes the same
 diagnostic counters (`duration_ms`, `google_requests`, `amo_requests`,
 `retries`, `rate_limit_hits`, `pages_*`) alongside the existing summary.
 
+Supported filters:
+
+- `amo_ids=ID1,ID2,...` – limit the sync to specific Amo contacts.
+- `since_minutes` / `since_days` – behave the same way as in `dry-run` and can
+  be combined with `amo_ids`. Filtering is applied before the final `limit` is
+  enforced.
+
 For safe manual testing prefer small batches and pauses between runs, e.g.:
 
 ```bash

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ def test_dry_run_no_token(monkeypatch):
     sess.commit()
     sess.close()
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         return []
 
     monkeypatch.setattr(sync_route, "fetch_amo_contacts", fake_fetch_amo)
@@ -62,7 +62,7 @@ def test_dry_run_ok(monkeypatch):
             {"requests": 1, "considered": 1, "found": 0},
         )
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
 
     monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
@@ -86,7 +86,7 @@ def test_dry_run_ok(monkeypatch):
 def test_dry_run_direction_amo(monkeypatch):
     from app.routes import sync as sync_route
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
 
     async def fake_fetch_google(
@@ -135,7 +135,7 @@ def test_dry_run_direction_google(monkeypatch):
             {"requests": 1, "considered": 1, "found": 0},
         )
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         return []
 
     monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)
@@ -175,7 +175,7 @@ def test_dry_run_since_days(monkeypatch):
     async def fake_search_contacts(query, counters=None):  # noqa: ARG001
         return []
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         return []
 
     monkeypatch.setattr(google_people, "list_contacts", fake_list_contacts)
@@ -207,7 +207,7 @@ def test_dry_run_limit_clamped(monkeypatch):
     ):  # noqa: ARG001
         return ([], {"requests": 0, "considered": 0, "found": 0})
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         if stats is not None:
             stats["amo_requests"] = stats.get("amo_requests", 0) + 1
             stats["pages_amo"] = stats.get("pages_amo", 0) + 1
@@ -231,7 +231,7 @@ def test_dry_run_since_minutes(monkeypatch):
 
     observed: dict[str, int | None] = {}
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         observed["since_days"] = since_days
         observed["since_minutes"] = since_minutes
         return []
@@ -263,7 +263,7 @@ def test_dry_run_fast_both_partial_timeout(monkeypatch):
     ):  # noqa: ARG001
         raise asyncio.TimeoutError
 
-    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, stats=None):  # noqa: ARG001
+    async def fake_fetch_amo(limit, since_days=None, since_minutes=None, *, amo_ids=None, stats=None):  # noqa: ARG001
         return [{"id": 1, "name": "a", "emails": ["a@ex.com"], "phones": []}]
 
     monkeypatch.setattr(sync_route, "fetch_google_contacts", fake_fetch_google)


### PR DESCRIPTION
## Summary
- allow /sync/contacts/apply to accept Amo contact IDs and fresh-since filters
- update Amo contact fetcher to respect amo_id order, apply filters before limit, and pass filters from the apply sync
- document the new filters and expand tests to cover them

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d40e36c1c88327bb8831aae5fda0a0