### PR TITLE
Explain skip reasons for unchanged contacts

### DIFF
--- a/app/sync.py
+++ b/app/sync.py
@@ -375,6 +375,14 @@ async def apply_contacts_to_google(
                             updated_samples.append(sample)
                     else:
                         skip_existing += 1
+                        reason: List[str] = []
+                        if not need_name:
+                            reason.append("name")
+                        if not missing_phones:
+                            reason.append("phones")
+                        if not missing_emails:
+                            reason.append("emails")
+                        sample["reason"] = reason
                         if len(skipped_samples) < 5:
                             skipped_samples.append(sample)
                 else:

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -77,6 +77,8 @@ def test_apply_upserts(monkeypatch):
         assert creates == [3]
         assert [u[0] for u in updates] == ["people/1"]
         assert updates[0][1] == "e1"
+        skip_sample = data["samples"]["skip_existing"][0]
+        assert skip_sample["reason"] == ["name", "phones", "emails"]
 
 
 def test_apply_missing_etag(monkeypatch):


### PR DESCRIPTION
## Summary
- add a detailed reason list to skip_existing samples when no Google contact update is needed
- extend apply sync tests to verify the new reason data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40e4835448327848d9b2c02af8218