### PR TITLE
Add webhook debug endpoint to expose recent events

### DIFF
--- a/app/debug.py
+++ b/app/debug.py
@@ -12,8 +12,11 @@ from app.config import settings
 from app.google_auth import GoogleAuthError, get_valid_google_access_token
 from app.google_people import GOOGLE_API_BASE
 from app.storage import Token, get_session, get_token
+from app.webhooks import get_recent_webhook_events
 
 router = APIRouter()
+
+_ACCEPTED_WEBHOOK_AUTH = ("X-Webhook-Secret", "X-Debug-Secret", "?token")
 
 
 def require_debug_secret(
@@ -252,3 +255,11 @@ async def ping_google(_=Depends(require_debug_secret)) -> dict[str, object]:
     if error_reason:
         response["error_reason"] = error_reason
     return response
+
+
+@router.get("/webhook")
+def debug_webhook(_=Depends(require_debug_secret)) -> dict[str, object]:
+    return {
+        "accepted_auth": list(_ACCEPTED_WEBHOOK_AUTH),
+        "last_events": get_recent_webhook_events(),
+    }

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import deque
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Set
 
 from fastapi import APIRouter, Header, HTTPException, Query
@@ -9,6 +11,26 @@ from app.config import settings
 from app.pending_sync_worker import enqueue_contact, pending_sync_worker
 
 router = APIRouter()
+
+_RECENT_WEBHOOK_EVENTS = deque(maxlen=10)
+
+
+def _record_webhook_event(event: str, contact_id: int) -> None:
+    _RECENT_WEBHOOK_EVENTS.appendleft(
+        {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+            "contact_id": contact_id,
+        }
+    )
+
+
+def get_recent_webhook_events() -> List[Dict[str, Any]]:
+    return list(_RECENT_WEBHOOK_EVENTS)
+
+
+def clear_recent_webhook_events() -> None:
+    _RECENT_WEBHOOK_EVENTS.clear()
 
 
 def _provided_secret(header: str | None, token: str | None) -> str | None:
@@ -50,6 +72,30 @@ def _extract_contact_ids(payload: Dict[str, Any]) -> List[int]:
     return [cid for cid in ids if cid > 0]
 
 
+def _guess_event_name(payload: Dict[str, Any], contact_id: int) -> str:
+    event = payload.get("event")
+    if isinstance(event, str) and event:
+        return event
+
+    contacts_section = payload.get("contacts")
+    if isinstance(contacts_section, dict):
+        for key in ("add", "update", "delete"):
+            events = contacts_section.get(key)
+            if not isinstance(events, list):
+                continue
+            for item in events:
+                if not isinstance(item, dict):
+                    continue
+                try:
+                    item_id = int(item.get("id"))
+                except (TypeError, ValueError):
+                    continue
+                if item_id == contact_id:
+                    return f"contacts.{key}"
+
+    return "contact_updated"
+
+
 @router.post("/webhook/amo")
 async def webhook_amo(
     payload: Dict[str, Any],
@@ -65,6 +111,7 @@ async def webhook_amo(
     for contact_id in contact_ids:
         enqueue_contact(contact_id)
         queued.append(contact_id)
+        _record_webhook_event(_guess_event_name(payload, contact_id), contact_id)
 
     logger.info("webhook.queued", count=len(queued), ids=queued)
     pending_sync_worker.wake()


### PR DESCRIPTION
## Summary
- add a `/debug/webhook` endpoint to return accepted auth headers and recent webhook activity
- capture webhook invocations with timestamps and inferred event names for debugging
- cover the new endpoint with tests ensuring a rolling window of the latest 10 events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40e5a493c83278f06da55a7516a17