### PR TITLE
Add AmoCRM auth mode config loader and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Available endpoints:
 | `GET /debug/db` | Database connectivity and number of stored tokens |
 | `GET /debug/google` | Google token status: `has_token`, `expires_at`, `scopes` |
 | `GET /debug/amo` | AmoCRM configuration: `base_url`, `auth_mode`, `is_ready` |
+| `GET /debug/config` | Snapshot of AmoCRM auth mode and whether the required secrets are present |
 | `GET /debug/ping-google` | Quick Google People API probe with latency and retry hints |
 
 Example:
@@ -64,6 +65,21 @@ fields. When the service is rate limited it returns HTTP 200 with
 A missing/expired token yields HTTP 401 with the usual
 `{"detail": "Google auth required", "auth_url": "/auth/google/start"}`
 payload.
+
+## AmoCRM authentication
+
+Set `AMO_AUTH_MODE` to either `llt` (long-lived token) or `api_key`. This value is
+the single source of truth for the AmoCRM auth mode: no automatic fallbacks are
+performed. Depending on the mode you must provide **exactly one** of the
+following secrets via environment variables:
+
+* `AMO_LONG_LIVED_TOKEN` when `AMO_AUTH_MODE=llt`.
+* `AMO_API_KEY` when `AMO_AUTH_MODE=api_key`.
+
+Use `/debug/config` (guarded by `DEBUG_SECRET`) to verify which mode the service
+detected and whether the corresponding secret is available. At application
+startup the current configuration is logged in a sanitized form to aid
+troubleshooting.
 
 ## Sync API
 

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application utilities."""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,83 @@
+"""Configuration helpers for AmoCRM integration."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, Tuple
+
+
+def _norm(value: str | None) -> str:
+    """Normalize environment variables by trimming whitespace."""
+
+    return (value or "").strip()
+
+
+def _load_settings() -> Dict[str, Any]:
+    """Load AmoCRM-related settings from environment variables."""
+
+    mode = _norm(os.getenv("AMO_AUTH_MODE")).lower()
+    base_url = _norm(os.getenv("AMO_BASE_URL")) or "https://example.amocrm.ru"
+    api_key = _norm(os.getenv("AMO_API_KEY"))
+    llt = _norm(os.getenv("AMO_LONG_LIVED_TOKEN"))
+    return {
+        "amo_auth_mode": mode,
+        "amo_base_url": base_url,
+        "amo_has_api_key": bool(api_key),
+        "amo_has_llt": bool(llt),
+    }
+
+
+def _validate(settings: Dict[str, Any]) -> None:
+    """Validate the AmoCRM configuration."""
+
+    mode = settings.get("amo_auth_mode")
+    if mode not in ("llt", "api_key"):
+        raise RuntimeError(f"Invalid AMO_AUTH_MODE: {mode or '<empty>'}")
+    if mode == "llt" and not settings.get("amo_has_llt"):
+        raise RuntimeError("AmoCRM LLT missing")
+    if mode == "api_key" and not settings.get("amo_has_api_key"):
+        raise RuntimeError("AmoCRM API key missing")
+
+
+@lru_cache(maxsize=1)
+def _get_settings_cached() -> Dict[str, Any]:
+    settings = _load_settings()
+    _validate(settings)
+    return settings
+
+
+def get_settings(*, validate: bool = True) -> Dict[str, Any]:
+    """Return AmoCRM configuration.
+
+    Parameters
+    ----------
+    validate:
+        When ``True`` (default) the settings are validated and cached. When
+        ``False`` the raw values are returned without validation or caching.
+    """
+
+    if validate:
+        return _get_settings_cached()
+    return _load_settings()
+
+
+def get_settings_snapshot() -> Tuple[Dict[str, Any], RuntimeError | None]:
+    """Return current settings alongside a validation error, if any."""
+
+    settings = _load_settings()
+    try:
+        _validate(settings)
+    except RuntimeError as exc:
+        return settings, exc
+    return settings, None
+
+
+def clear_settings_cache() -> None:
+    """Clear the cached AmoCRM settings."""
+
+    _get_settings_cached.cache_clear()
+
+
+# Expose ``cache_clear`` to ease testing (pytest expects attribute on function).
+get_settings.cache_clear = clear_settings_cache  # type: ignore[attr-defined]

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from app.auth import router as auth_router
 from app.backfill import router as backfill_router
 from app.config import settings
+from app.core.config import get_settings_snapshot
 from app.debug import router as debug_router
 from app.routes.sync import router as sync_router
 from app.pending_sync_worker import pending_sync_worker
@@ -21,6 +22,17 @@ def create_app() -> FastAPI:
     async def _startup() -> None:
         init_db()
         pending_sync_worker.start()
+        amo_snapshot, amo_error = get_settings_snapshot()
+        logger.info(
+            "amo.config auth_mode=%s base_url=%s has_api_key=%s has_llt=%s valid=%s",
+            amo_snapshot.get("amo_auth_mode") or "<unset>",
+            amo_snapshot.get("amo_base_url") or "<unset>",
+            bool(amo_snapshot.get("amo_has_api_key")),
+            bool(amo_snapshot.get("amo_has_llt")),
+            amo_error is None,
+        )
+        if amo_error:
+            logger.error("amo.config_invalid %s", amo_error)
         if settings.debug_secret:
             logger.info("Debug router enabled on /debug")
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_amo_settings_cache():
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from app.core.config import get_settings, get_settings_snapshot

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.core.config import get_settings, get_settings_snapshot
+
+
+def _setenv(monkeypatch: pytest.MonkeyPatch, **values: str) -> None:
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+
+
+def _delenv(monkeypatch: pytest.MonkeyPatch, *keys: str) -> None:
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_get_settings_long_lived_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setenv(
+        monkeypatch,
+        AMO_AUTH_MODE="llt",
+        AMO_LONG_LIVED_TOKEN=" token ",
+        AMO_BASE_URL=" https://example.amocrm.ru ",
+    )
+    _delenv(monkeypatch, "AMO_API_KEY")
+    settings = get_settings()
+    assert settings["amo_auth_mode"] == "llt"
+    assert settings["amo_has_llt"] is True
+    assert settings["amo_has_api_key"] is False
+    assert settings["amo_base_url"] == "https://example.amocrm.ru"
+
+
+def test_get_settings_long_lived_token_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setenv(monkeypatch, AMO_AUTH_MODE="llt", AMO_LONG_LIVED_TOKEN="")
+    with pytest.raises(RuntimeError, match="AmoCRM LLT missing"):
+        get_settings()
+
+
+def test_get_settings_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setenv(monkeypatch, AMO_AUTH_MODE="api_key", AMO_API_KEY=" key ")
+    _delenv(monkeypatch, "AMO_LONG_LIVED_TOKEN")
+    settings = get_settings()
+    assert settings["amo_auth_mode"] == "api_key"
+    assert settings["amo_has_api_key"] is True
+    assert settings["amo_has_llt"] is False
+
+
+def test_get_settings_api_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setenv(monkeypatch, AMO_AUTH_MODE="api_key")
+    _delenv(monkeypatch, "AMO_API_KEY")
+    with pytest.raises(RuntimeError, match="AmoCRM API key missing"):
+        get_settings()
+
+
+def test_get_settings_snapshot_reports_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _setenv(monkeypatch, AMO_AUTH_MODE="api_key")
+    snapshot, error = get_settings_snapshot()
+    assert snapshot["amo_auth_mode"] == "api_key"
+    assert snapshot["amo_has_api_key"] is False
+    assert error is not None
+    assert "AmoCRM API key missing" in str(error)

--- a/tests/test_pending_sync_worker.py
+++ b/tests/test_pending_sync_worker.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.pending_sync_worker import PendingSyncWorker
+from app.storage import PendingSync, enqueue_pending_sync, get_session, init_db
+
+
+@pytest.mark.asyncio
+async def test_worker_dead_letters_on_missing_amo_token(monkeypatch):
+    init_db()
+    session = get_session()
+    try:
+        record = enqueue_pending_sync(session, 123)
+        record_id = record.id
+    finally:
+        session.close()
+
+    async def missing_contact(contact_id: int):  # noqa: D401
+        raise RuntimeError("AmoCRM API key missing")
+
+    monkeypatch.setattr("app.pending_sync_worker.get_contact", missing_contact)
+
+    worker = PendingSyncWorker()
+    session = get_session()
+    try:
+        record = session.get(PendingSync, record_id)
+        assert record is not None
+        await worker._handle_record(session, record)
+        session.refresh(record)
+        stored_error = record.last_error
+        stored_attempts = record.attempts
+        next_attempt_at = record.next_attempt_at
+    finally:
+        session.close()
+
+    assert stored_error.startswith("amo_auth_missing")
+    assert stored_attempts == 1
+    assert next_attempt_at > datetime.utcnow() + timedelta(days=3000)


### PR DESCRIPTION
## Summary
- introduce a centralized AmoCRM configuration loader that validates AMO_AUTH_MODE and exposes snapshot helpers for diagnostics
- update the AmoCRM client, debug endpoints, worker, and sync logic to respect the configured auth mode and log configuration on startup
- document the new /debug/config endpoint and add unit/integration tests covering the loader, diagnostics, and worker dead-letter handling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9989cf73c8327bd228bcfb27386b3