### PR TITLE
Ensure Google OAuth tokens auto-refresh and expose status

### DIFF
--- a/alembic/versions/20240514_000003_add_settings_table.py
+++ b/alembic/versions/20240514_000003_add_settings_table.py
@@ -1,0 +1,37 @@
+"""add settings table
+
+Revision ID: 20240514_000003
+Revises: 20240221_000002
+Create Date: 2024-05-14 00:00:03.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240514_000003"
+down_revision = "20240221_000002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "settings",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("key", sa.String(), nullable=False, unique=True),
+        sa.Column("value", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")

--- a/app/auth.py
+++ b/app/auth.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 from fastapi.responses import RedirectResponse
 
 from app.config import settings
+from app.google_auth import mark_google_auth_ready
 from app.storage import get_session, get_token, save_token
 
 router = APIRouter()
@@ -57,6 +58,7 @@ async def auth_google_callback(code: str):
             expiry=expiry,
             scopes=settings.google_scopes,
         )
+        mark_google_auth_ready(session)
     finally:
         session.close()
     return {"status": "ok"}

--- a/app/debug.py
+++ b/app/debug.py
@@ -11,7 +11,11 @@ from sqlalchemy import select
 from app.amocrm import extract_name_and_fields, get_contact
 from app.config import settings
 from app.core.config import get_settings_snapshot
-from app.google_auth import GoogleAuthError, get_valid_google_access_token
+from app.google_auth import (
+    GoogleAuthError,
+    get_google_auth_state,
+    get_valid_google_access_token,
+)
 from app.google_people import GOOGLE_API_BASE
 from app.services.sync_engine import SyncEngine
 from app.storage import Token, get_session, get_token
@@ -60,10 +64,23 @@ def debug_google(_=Depends(require_debug_secret)) -> dict[str, object]:
     session = get_session()
     try:
         token = get_token(session, "google")
+        state = get_google_auth_state(session)
+        payload: dict[str, object] = {
+            "auth_status": state.auth_status,
+            "last_refresh": state.last_refresh.isoformat().replace("+00:00", "Z")
+            if state.last_refresh
+            else None,
+            "expires_in": state.expires_in,
+            "failure_count": state.failure_count,
+        }
+        if state.last_error:
+            payload["last_error"] = state.last_error
         if not token:
-            return {"has_token": False, "expires_at": None, "scopes": None}
+            payload.update({"has_token": False, "expires_at": None, "scopes": None})
+            return payload
         expires = token.expiry.isoformat() if token.expiry else None
-        return {"has_token": True, "expires_at": expires, "scopes": token.scopes}
+        payload.update({"has_token": True, "expires_at": expires, "scopes": token.scopes})
+        return payload
     finally:
         session.close()
 

--- a/app/google_auth.py
+++ b/app/google_auth.py
@@ -9,6 +9,7 @@ callers can react appropriately (e.g. by asking the user to re-authorise).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -16,10 +17,18 @@ from typing import Optional
 import httpx
 
 from app.config import settings
-from app.storage import Token, get_token, save_token
+from app.storage import Token, get_setting, get_token, save_token, set_settings
 
 
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+AUTH_STATUS_OK = "ok"
+AUTH_STATUS_NEEDS_REAUTH = "needs_reauth"
+SETTING_AUTH_STATUS = "google_auth_status"
+SETTING_LAST_REFRESH = "google_last_refresh"
+SETTING_REFRESH_FAILURES = "google_refresh_failures"
+SETTING_LAST_ERROR = "google_last_refresh_error"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -30,11 +39,50 @@ class GoogleAuthError(Exception):
     auth_url: Optional[str] = None
 
 
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _serialize_dt(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _record_auth_ready(session, *, refreshed_at: Optional[datetime] = None) -> None:
+    refreshed_at = refreshed_at or _utcnow()
+    set_settings(
+        session,
+        {
+            SETTING_AUTH_STATUS: AUTH_STATUS_OK,
+            SETTING_LAST_REFRESH: _serialize_dt(refreshed_at),
+            SETTING_REFRESH_FAILURES: "0",
+            SETTING_LAST_ERROR: None,
+        },
+    )
+
+
+def _record_auth_failure(session, reason: str) -> int:
+    try:
+        failures = int(get_setting(session, SETTING_REFRESH_FAILURES) or "0")
+    except ValueError:
+        failures = 0
+    failures += 1
+    payload = {
+        SETTING_AUTH_STATUS: AUTH_STATUS_NEEDS_REAUTH,
+        SETTING_REFRESH_FAILURES: str(failures),
+        SETTING_LAST_ERROR: reason,
+    }
+    set_settings(session, payload)
+    return failures
+
+
 async def _refresh_token(session) -> Token:
     """Refresh the Google OAuth token stored in the database."""
 
     token = get_token(session, "google")
     if not token or not token.refresh_token:
+        _record_auth_failure(session, "refresh_unavailable")
         raise GoogleAuthError("refresh_unavailable", "/auth/google/start")
 
     data = {
@@ -47,9 +95,17 @@ async def _refresh_token(session) -> Token:
     try:
         resp = httpx.post(GOOGLE_TOKEN_URL, data=data, timeout=10)
     except httpx.RequestError as exc:  # pragma: no cover - network errors are rare
+        logger.warning("google.refresh_request_error error=%s", exc)
         raise GoogleAuthError(f"network_error: {exc}")
 
     if resp.status_code != 200:
+        reason = f"http_{resp.status_code}"
+        failures = _record_auth_failure(session, reason)
+        if failures > 3:
+            logger.error(
+                "google.refresh_failed_repeatedly",
+                extra={"failures": failures, "status": resp.status_code},
+            )
         raise GoogleAuthError("refresh_failed", "/auth/google/start")
 
     payload = resp.json()
@@ -57,7 +113,8 @@ async def _refresh_token(session) -> Token:
     expires_in = payload.get("expires_in", 0)
     new_refresh = payload.get("refresh_token") or token.refresh_token
 
-    expiry = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+    refresh_time = _utcnow()
+    expiry = refresh_time + timedelta(seconds=int(expires_in))
     save_token(
         session,
         "google",
@@ -67,10 +124,22 @@ async def _refresh_token(session) -> Token:
         scopes=token.scopes or "",
         account_id=token.account_id,
     )
+    _record_auth_ready(session, refreshed_at=refresh_time)
     return get_token(session, "google")
 
 
-async def get_valid_google_access_token(session) -> str:
+def _ensure_token(session) -> Token:
+    token = get_token(session, "google")
+    if not token:
+        _record_auth_failure(session, "token_missing")
+        raise GoogleAuthError("token_missing", "/auth/google/start")
+    if not token.refresh_token:
+        _record_auth_failure(session, "refresh_unavailable")
+        raise GoogleAuthError("refresh_unavailable", "/auth/google/start")
+    return token
+
+
+async def get_valid_google_access_token(session, *, force_refresh: bool = False) -> str:
     """Return a valid access token for Google APIs.
 
     If the current token is close to expiring (within 60 seconds) it is
@@ -78,12 +147,11 @@ async def get_valid_google_access_token(session) -> str:
     is missing or cannot be refreshed.
     """
 
-    token = get_token(session, "google")
-    if not token:
-        raise GoogleAuthError("token_missing", "/auth/google/start")
+    token = _ensure_token(session)
 
     now = datetime.utcnow()
-    if not token.expiry or token.expiry <= now + timedelta(seconds=60):
+    should_refresh = force_refresh or not token.expiry or token.expiry <= now + timedelta(seconds=60)
+    if should_refresh:
         token = await _refresh_token(session)
 
     return token.access_token
@@ -98,4 +166,59 @@ async def force_refresh_google_access_token(session) -> str:
 
     token = await _refresh_token(session)
     return token.access_token
+
+
+@dataclass
+class GoogleAuthState:
+    auth_status: str
+    last_refresh: Optional[datetime]
+    expires_in: Optional[int]
+    failure_count: int
+    last_error: Optional[str]
+
+
+def get_google_auth_state(session) -> GoogleAuthState:
+    token = get_token(session, "google")
+    status = get_setting(session, SETTING_AUTH_STATUS) or AUTH_STATUS_NEEDS_REAUTH
+    if status not in {AUTH_STATUS_OK, AUTH_STATUS_NEEDS_REAUTH}:
+        status = AUTH_STATUS_NEEDS_REAUTH
+
+    last_refresh_raw = get_setting(session, SETTING_LAST_REFRESH)
+    last_refresh: Optional[datetime] = None
+    if last_refresh_raw:
+        try:
+            last_refresh = datetime.fromisoformat(last_refresh_raw.replace("Z", "+00:00"))
+        except ValueError:
+            last_refresh = None
+
+    expires_in: Optional[int] = None
+    if token and token.expiry:
+        delta = int((token.expiry - datetime.utcnow()).total_seconds())
+        expires_in = delta if delta >= 0 else 0
+
+    try:
+        failures = int(get_setting(session, SETTING_REFRESH_FAILURES) or "0")
+    except ValueError:
+        failures = 0
+    last_error = get_setting(session, SETTING_LAST_ERROR)
+
+    if not token or not token.refresh_token:
+        status = AUTH_STATUS_NEEDS_REAUTH
+
+    return GoogleAuthState(
+        auth_status=status,
+        last_refresh=last_refresh,
+        expires_in=expires_in,
+        failure_count=failures,
+        last_error=last_error,
+    )
+
+
+def google_auth_needs_reauth(session) -> bool:
+    state = get_google_auth_state(session)
+    return state.auth_status == AUTH_STATUS_NEEDS_REAUTH
+
+
+def mark_google_auth_ready(session) -> None:
+    _record_auth_ready(session)
 

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,10 @@ from app.backfill import router as backfill_router
 from app.config import settings
 from app.core.config import get_settings_snapshot
 from app.debug import router as debug_router
+from app.google_auth import get_google_auth_state
 from app.routes.sync import router as sync_router
 from app.pending_sync_worker import pending_sync_worker
-from app.storage import init_db
+from app.storage import get_session, init_db
 from app.webhooks import router as webhook_router
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,22 @@ def create_app() -> FastAPI:
     @app.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/status")
+    async def status() -> dict[str, object]:
+        session = get_session()
+        try:
+            state = get_google_auth_state(session)
+            return {
+                "auth_status": state.auth_status,
+                "last_refresh": state.last_refresh.isoformat().replace("+00:00", "Z")
+                if state.last_refresh
+                else None,
+                "expires_in": state.expires_in,
+                "failure_count": state.failure_count,
+            }
+        finally:
+            session.close()
 
     app.include_router(auth_router)
     app.include_router(webhook_router)

--- a/app/pending_sync_worker.py
+++ b/app/pending_sync_worker.py
@@ -7,6 +7,11 @@ from typing import Optional
 from loguru import logger
 
 from app.amocrm import extract_name_and_fields, get_contact
+from app.google_auth import (
+    GoogleAuthError,
+    get_valid_google_access_token,
+    google_auth_needs_reauth,
+)
 from app.google_people import GoogleRateLimitError
 from app.storage import (
     PendingSync,
@@ -25,6 +30,7 @@ class PendingSyncWorker:
         self._wake_event: asyncio.Event | None = None
         self._lock: asyncio.Lock | None = None
         self._stopping = False
+        self._refresh_task: asyncio.Task | None = None
 
     def start(self) -> None:
         if self._task and not self._task.done():
@@ -34,12 +40,15 @@ class PendingSyncWorker:
         self._lock = asyncio.Lock()
         self._stopping = False
         self._task = loop.create_task(self._run())
+        self._refresh_task = loop.create_task(self._refresh_loop())
         logger.info("pending_sync.worker_started")
 
     async def stop(self) -> None:
         self._stopping = True
         if self._wake_event:
             self._wake_event.set()
+        if self._refresh_task:
+            self._refresh_task.cancel()
         if self._task:
             try:
                 await self._task
@@ -48,6 +57,12 @@ class PendingSyncWorker:
             self._task = None
         self._wake_event = None
         self._lock = None
+        if self._refresh_task:
+            try:
+                await self._refresh_task
+            except asyncio.CancelledError:
+                pass
+            self._refresh_task = None
         logger.info("pending_sync.worker_stopped")
 
     def wake(self) -> None:
@@ -90,6 +105,9 @@ class PendingSyncWorker:
         async with lock:
             session = get_session()
             try:
+                if google_auth_needs_reauth(session):
+                    logger.warning("Skipping sync: Google authorization required")
+                    return 0
                 records = fetch_due_pending_sync(session, limit)
                 processed = 0
                 for record in records:
@@ -98,6 +116,37 @@ class PendingSyncWorker:
                 return processed
             finally:
                 session.close()
+
+    async def _refresh_loop(self) -> None:
+        interval = 12 * 60 * 60
+        try:
+            while not self._stopping:
+                session = get_session()
+                try:
+                    try:
+                        await get_valid_google_access_token(session, force_refresh=True)
+                    except GoogleAuthError as exc:
+                        logger.warning(
+                            "google.token_refresh_failed reason=%s",
+                            exc.reason,
+                        )
+                    else:
+                        logger.info("google.token_refreshed")
+                finally:
+                    session.close()
+                for _ in range(interval // 60):
+                    if self._stopping:
+                        break
+                    await asyncio.sleep(60)
+                else:
+                    remainder = interval % 60
+                    if remainder:
+                        await asyncio.sleep(remainder)
+                if self._stopping:
+                    break
+        except asyncio.CancelledError:
+            logger.debug("pending_sync.refresh_cancelled")
+            raise
 
     async def _handle_record(self, session, record: PendingSync) -> None:
         contact_id = int(record.amo_contact_id)

--- a/app/storage.py
+++ b/app/storage.py
@@ -65,6 +65,16 @@ class Token(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
+class Setting(Base):
+    __tablename__ = "settings"
+
+    id = Column(Integer, primary_key=True)
+    key = Column(String, unique=True, nullable=False)
+    value = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
 class PendingSync(Base):
     __tablename__ = "pending_sync"
 
@@ -104,6 +114,32 @@ def save_token(session, system: str, access_token: str, refresh_token: str, expi
     session.commit()
     session.refresh(token)
     return token
+
+
+def get_setting(session, key: str) -> Optional[str]:
+    stmt = select(Setting).where(Setting.key == key)
+    record = session.execute(stmt).scalars().first()
+    return record.value if record else None
+
+
+def set_settings(session, values: dict[str, Optional[str]]) -> None:
+    if not values:
+        return
+    stmt = select(Setting).where(Setting.key.in_(values.keys()))
+    existing = {setting.key: setting for setting in session.execute(stmt).scalars().all()}
+    now = datetime.utcnow()
+    for key, value in values.items():
+        record = existing.get(key)
+        if record:
+            record.value = value
+            record.updated_at = now
+        else:
+            session.add(Setting(key=key, value=value, created_at=now, updated_at=now))
+    session.commit()
+
+
+def set_setting(session, key: str, value: Optional[str]) -> None:
+    set_settings(session, {key: value})
 
 def get_link(session, amo_contact_id: str) -> Optional[Link]:
     stmt = select(Link).where(Link.amo_contact_id == amo_contact_id)

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -6,8 +6,12 @@ import pytest
 
 from app import google_people
 from app.auth import auth_google_callback
-from app.google_auth import get_valid_google_access_token
-from app.storage import Token, get_session, save_token, init_db
+from app.google_auth import (
+    GoogleAuthError,
+    get_google_auth_state,
+    get_valid_google_access_token,
+)
+from app.storage import Token, get_session, init_db, save_token
 
 
 class DummyResponse:
@@ -37,11 +41,32 @@ def test_token_refresh(monkeypatch):
 
     token = asyncio.run(get_valid_google_access_token(session))
     assert token == "new"
+    state = get_google_auth_state(session)
+    assert state.auth_status == "ok"
     session.close()
 
     session = get_session()
     stored = session.get(Token, 1)
     assert stored.access_token == "new"
+    session.close()
+
+
+def test_refresh_failure_marks_needs_reauth(monkeypatch):
+    init_db()
+    session = get_session()
+    expiry = datetime.utcnow() - timedelta(seconds=10)
+    save_token(session, "google", "old", "refresh", expiry, scopes="")
+
+    def fake_post(url, data, timeout):  # noqa: ARG001
+        return DummyResponse(400)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    with pytest.raises(GoogleAuthError):
+        asyncio.run(get_valid_google_access_token(session))
+
+    state = get_google_auth_state(session)
+    assert state.auth_status == "needs_reauth"
     session.close()
 
 
@@ -152,5 +177,7 @@ async def test_google_callback_reuses_refresh_token(monkeypatch):
     stored = session.query(Token).filter(Token.system == "google").one()
     assert stored.access_token == "new"
     assert stored.refresh_token == "refresh"
+    state = get_google_auth_state(session)
+    assert state.auth_status == "ok"
     session.close()
 


### PR DESCRIPTION
## Summary
- add a settings table and enhance the Google OAuth refresh flow to persist state, auto-refresh tokens, and surface reauth requirements
- expose Google auth health via /status and richer /debug/google output while updating the worker to skip syncs when reauth is required and refresh tokens every 12 hours
- extend tests to cover the new auth state behaviour and include a migration for the settings table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ef6ff1176483279f8e0866a9891333