### PR TITLE
AGC-017: sanitize Google merge payloads and guard ambiguous amo phones

### DIFF
--- a/app/integrations/google_client.py
+++ b/app/integrations/google_client.py
@@ -12,6 +12,143 @@ from app.storage import get_session
 _GROUP_CACHE: Dict[str, str] = {}
 _GROUP_LOCK = asyncio.Lock()
 _GROUP_CLIENT_DATA_KEY = "amo_google_sync_group"
+_WRITABLE_TOP_LEVEL_FIELDS = {
+    "addresses",
+    "biographies",
+    "birthdays",
+    "calendarUrls",
+    "clientData",
+    "emailAddresses",
+    "events",
+    "externalIds",
+    "genders",
+    "imClients",
+    "interests",
+    "locales",
+    "locations",
+    "memberships",
+    "miscKeywords",
+    "names",
+    "nicknames",
+    "occupations",
+    "organizations",
+    "phoneNumbers",
+    "relations",
+    "sipAddresses",
+    "urls",
+    "userDefined",
+}
+
+
+def _sanitize_entries(
+    entries: Any,
+    *,
+    allowed_fields: Set[str],
+) -> List[Dict[str, Any]]:
+    result: List[Dict[str, Any]] = []
+    if not isinstance(entries, list):
+        return result
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        clean = {
+            key: value
+            for key, value in entry.items()
+            if key in allowed_fields and value is not None
+        }
+        if clean:
+            result.append(clean)
+    return result
+
+
+def sanitize_person_for_update(person: Mapping[str, Any]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    if not isinstance(person, Mapping):
+        return payload
+
+    for field in _WRITABLE_TOP_LEVEL_FIELDS:
+        value = person.get(field)
+        if value is not None:
+            payload[field] = deepcopy(value)
+
+    payload["phoneNumbers"] = _sanitize_entries(
+        payload.get("phoneNumbers"),
+        allowed_fields={"value", "type"},
+    )
+    if not payload["phoneNumbers"]:
+        payload.pop("phoneNumbers", None)
+
+    payload["emailAddresses"] = _sanitize_entries(
+        payload.get("emailAddresses"),
+        allowed_fields={"value", "type"},
+    )
+    if not payload["emailAddresses"]:
+        payload.pop("emailAddresses", None)
+
+    payload["names"] = _sanitize_entries(
+        payload.get("names"),
+        allowed_fields={
+            "displayName",
+            "givenName",
+            "familyName",
+            "middleName",
+            "honorificPrefix",
+            "honorificSuffix",
+            "phoneticGivenName",
+            "phoneticFamilyName",
+            "phoneticMiddleName",
+            "phoneticHonorificPrefix",
+            "phoneticHonorificSuffix",
+            "unstructuredName",
+        },
+    )
+    if not payload["names"]:
+        payload.pop("names", None)
+
+    memberships: List[Dict[str, Any]] = []
+    for entry in payload.get("memberships", []) or []:
+        if not isinstance(entry, Mapping):
+            continue
+        group = entry.get("contactGroupMembership")
+        if not isinstance(group, Mapping):
+            continue
+        group_name = group.get("contactGroupResourceName")
+        if not group_name:
+            continue
+        memberships.append(
+            {
+                "contactGroupMembership": {
+                    "contactGroupResourceName": group_name,
+                }
+            }
+        )
+    if memberships:
+        payload["memberships"] = memberships
+    else:
+        payload.pop("memberships", None)
+
+    payload["biographies"] = _sanitize_entries(
+        payload.get("biographies"),
+        allowed_fields={"value", "contentType"},
+    )
+    if not payload["biographies"]:
+        payload.pop("biographies", None)
+
+    payload["externalIds"] = _sanitize_entries(
+        payload.get("externalIds"),
+        allowed_fields={"value", "type"},
+    )
+    if not payload["externalIds"]:
+        payload.pop("externalIds", None)
+
+    payload["clientData"] = _sanitize_entries(
+        payload.get("clientData"),
+        allowed_fields={"key", "value"},
+    )
+    if not payload["clientData"]:
+        payload.pop("clientData", None)
+
+    return payload
 
 
 def _normalize_update_fields(update_person_fields: Sequence[str] | str) -> Set[str]:
@@ -203,7 +340,7 @@ async def update_contact(
     try:
         headers = await _token_headers(session)
         headers["Content-Type"] = "application/json"
-        payload: MutableMapping[str, Any] = dict(body)
+        payload: MutableMapping[str, Any] = sanitize_person_for_update(body)
         payload["resourceName"] = resource_name
         if etag:
             payload["etag"] = etag
@@ -262,7 +399,7 @@ async def batch_update_contacts(
             fields.add("memberships")
         payload_contacts: Dict[str, Dict[str, Any]] = {}
         for key, data in contacts.items():
-            entry = dict(data)
+            entry = sanitize_person_for_update(data)
             if group_resource:
                 entry["memberships"] = _format_group_memberships(
                     entry.get("memberships"),

--- a/app/services/merge.py
+++ b/app/services/merge.py
@@ -42,8 +42,6 @@ def _merge_external_ids(persons: Sequence[Dict[str, Any]]) -> List[Dict[str, Any
                 external_entry["type"] = id_type
             if value is not None:
                 external_entry["value"] = value
-            if entry.get("metadata"):
-                external_entry["metadata"] = entry["metadata"]
             merged.append(external_entry)
     return merged
 
@@ -65,7 +63,7 @@ async def merge_contacts(
         "merge.start",
         extra={"primary": primary.resource_name, "duplicates": duplicate_names},
     )
-    logger.info("merge.primary=%s", primary.resource_name)
+    logger.info("merge.primary_selected", extra={"primary": primary.resource_name})
 
     persons = [c.person for c in duplicates]
     resolved_group = group_resource_name
@@ -83,6 +81,11 @@ async def merge_contacts(
     external_ids = _merge_external_ids([primary.person, *persons])
     if external_ids:
         payload["externalIds"] = external_ids
+    payload = google_client.sanitize_person_for_update(payload)
+    logger.info(
+        "merge.payload_sanitized",
+        extra={"primary": primary.resource_name, "fields": sorted(payload.keys())},
+    )
 
     etag = primary.person.get("etag")
     if not etag:
@@ -103,7 +106,7 @@ async def merge_contacts(
     )
 
     await google_client.batch_delete_contacts(duplicate_names)
-    logger.info("merge.deleted=%s", duplicate_names)
+    logger.info("merge.deleted", extra={"duplicates": duplicate_names})
 
     remap_google_links(db_session, primary.resource_name, duplicate_names)
 

--- a/app/services/sync_engine.py
+++ b/app/services/sync_engine.py
@@ -55,6 +55,7 @@ class SyncPlan:
     group_resource_name: Optional[str] = None
     candidate_info: List[SyncCandidateInfo] = field(default_factory=list)
     preflight_blocked_create: bool = False
+    ambiguous_phone_in_amo: bool = False
 
 
 @dataclass(slots=True)
@@ -123,9 +124,26 @@ class SyncEngine:
             group_resource_name=group_resource,
             mapped_resource_name=mapped_resource,
         )
+        ambiguous_phone = bool(contact.get("ambiguous_phone_in_amo"))
+        linked_candidates: List[MatchCandidate] = []
+        if mapped_resource:
+            linked_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.resource_name == mapped_resource
+            ]
+        if not linked_candidates and amo_id is not None:
+            linked_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.has_external_id(amo_contact_id=amo_id)
+            ]
 
         preflight_blocked = bool(candidates)
-        primary = choose_primary(candidates, keys, context) if candidates else None
+        if linked_candidates:
+            primary = choose_primary(linked_candidates, keys, context)
+        else:
+            primary = choose_primary(candidates, keys, context) if candidates else None
         duplicates = (
             [c for c in candidates if primary and c.resource_name != primary.resource_name]
             if candidates
@@ -139,12 +157,27 @@ class SyncEngine:
             else:
                 action = "create"
                 reason = "no_primary"
-        elif duplicates and self.auto_merge:
+        elif ambiguous_phone and not linked_candidates:
+            logger.warning(
+                "ambiguous_phone_in_amo",
+                extra={
+                    "amo_contact_id": amo_id,
+                    "phones": sorted(keys.phones),
+                    "candidates": [c.resource_name for c in candidates],
+                },
+            )
+            action = "skip"
+            reason = "ambiguous_phone_in_amo"
+        elif duplicates and self.auto_merge and not ambiguous_phone:
             action = "merge"
             reason = "duplicates_detected"
         else:
             action = "update"
-            reason = "single_candidate" if not duplicates else "duplicates_skip_merge"
+            reason = (
+                "single_candidate"
+                if not duplicates
+                else ("ambiguous_phone_in_amo" if ambiguous_phone else "duplicates_skip_merge")
+            )
 
         info = [
             SyncCandidateInfo(
@@ -170,6 +203,7 @@ class SyncEngine:
             group_resource_name=group_resource,
             candidate_info=info,
             preflight_blocked_create=preflight_blocked and action != "create",
+            ambiguous_phone_in_amo=ambiguous_phone,
         )
 
     async def apply(self, plan: SyncPlan) -> SyncResult:
@@ -317,6 +351,38 @@ class SyncEngine:
             )
         except MissingEtagError as exc:
             raise RecoverableSyncError(f"missing_etag:{exc.resource_name}") from exc
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 400:
+                raise
+            logger.error(
+                "merge.failed",
+                extra={
+                    "amo_contact_id": plan.amo_contact_id,
+                    "primary": primary.resource_name,
+                    "duplicates": [c.resource_name for c in plan.duplicates],
+                    "status_code": 400,
+                    "response_text": exc.response.text,
+                },
+            )
+            updated_resource = await self._update_contact(plan, primary)
+            logger.info(
+                "merge.fallback_update",
+                extra={
+                    "amo_contact_id": plan.amo_contact_id,
+                    "resource_name": updated_resource or primary.resource_name,
+                },
+            )
+            if updated_resource:
+                try:
+                    person = await google_client.get_contact(
+                        updated_resource,
+                        person_fields=PERSON_FIELDS,
+                    )
+                except Exception:
+                    return primary
+                refreshed = build_candidate_from_person(person, plan.keys)
+                return refreshed or primary
+            return primary
         return merged_primary
 
     async def _update_contact(
@@ -443,6 +509,16 @@ class SyncEngine:
     async def _post_create_merge(
         self, plan: SyncPlan, resource_name: str
     ) -> Optional[str]:
+        if plan.ambiguous_phone_in_amo:
+            logger.warning(
+                "ambiguous_phone_in_amo",
+                extra={
+                    "amo_contact_id": plan.amo_contact_id,
+                    "resource_name": resource_name,
+                    "reason": "postcreate_merge_skipped",
+                },
+            )
+            return resource_name
         candidates = await search_google_candidates(plan.keys)
         candidate_map = {candidate.resource_name: candidate for candidate in candidates}
 

--- a/app/services/transform.py
+++ b/app/services/transform.py
@@ -23,10 +23,6 @@ def _deduplicate_phones(persons: Sequence[Dict[str, Any]]) -> List[Dict[str, Any
             entry = {"value": normalized}
             if phone.get("type"):
                 entry["type"] = phone["type"]
-            if phone.get("metadata"):
-                entry["metadata"] = phone["metadata"]
-            if phone.get("formattedType"):
-                entry["formattedType"] = phone["formattedType"]
             merged.append(entry)
     return merged
 
@@ -48,8 +44,6 @@ def _deduplicate_emails(persons: Sequence[Dict[str, Any]]) -> List[Dict[str, Any
             entry = {"value": value}
             if email.get("type"):
                 entry["type"] = email["type"]
-            if email.get("metadata"):
-                entry["metadata"] = email["metadata"]
             merged.append(entry)
     return merged
 

--- a/app/sync.py
+++ b/app/sync.py
@@ -348,6 +348,19 @@ async def apply_contacts_to_google(
 
     service = SyncEngine()
     try:
+        phone_to_amo_ids: Dict[str, set[int]] = {}
+        for amo_contact in amo_contacts:
+            amo_id = amo_contact.get("id")
+            if amo_id is None:
+                continue
+            for raw_phone in amo_contact.get("phones", []) or []:
+                if not raw_phone:
+                    continue
+                normalized = normalize_phone(raw_phone)
+                if not normalized:
+                    continue
+                phone_to_amo_ids.setdefault(normalized, set()).add(int(amo_id))
+
         created_samples: List[Dict[str, Any]] = []
         updated_samples: List[Dict[str, Any]] = []
         skipped_samples: List[Dict[str, Any]] = []
@@ -369,6 +382,32 @@ async def apply_contacts_to_google(
                 "phones": contact.get("phones", []),
                 "emails": contact.get("emails", []),
             }
+            ambiguous_phones = sorted(
+                {
+                    normalized
+                    for phone in contact.get("phones", []) or []
+                    if phone and (normalized := normalize_phone(phone))
+                    and len(phone_to_amo_ids.get(normalized, set())) > 1
+                }
+            )
+            if ambiguous_phones:
+                contact = dict(contact)
+                contact["ambiguous_phone_in_amo"] = True
+                contact["ambiguous_phones"] = ambiguous_phones
+                logger.warning(
+                    "ambiguous_phone_in_amo",
+                    extra={
+                        "amo_contact_id": contact.get("id"),
+                        "phones": ambiguous_phones,
+                        "amo_ids": sorted(
+                            {
+                                amo_id
+                                for phone in ambiguous_phones
+                                for amo_id in phone_to_amo_ids.get(phone, set())
+                            }
+                        ),
+                    },
+                )
             try:
                 plan = await service.plan(contact)
                 result = await service.apply(plan)

--- a/tests/test_google_client.py
+++ b/tests/test_google_client.py
@@ -152,3 +152,55 @@ async def test_batch_update_contact_injects_membership(monkeypatch):
     assert memberships[0]["contactGroupMembership"]["contactGroupResourceName"] == "contactGroups/42"
     update_mask = payload["updateMask"].split(",")
     assert "memberships" in update_mask
+
+
+def test_sanitize_person_for_update_removes_read_only_fields():
+    person = {
+        "metadata": {"sources": [{"type": "CONTACT"}]},
+        "phoneNumbers": [
+            {
+                "value": "+79990000000",
+                "type": "mobile",
+                "metadata": {"primary": True},
+                "formattedType": "Моб.",
+            }
+        ],
+        "emailAddresses": [
+            {
+                "value": "a@example.com",
+                "type": "work",
+                "metadata": {"primary": True},
+                "source": {"type": "CONTACT"},
+            }
+        ],
+        "names": [
+            {
+                "displayName": "Alice Example",
+                "givenName": "Alice",
+                "metadata": {"primary": True},
+                "displayNameLastFirst": "Example, Alice",
+            }
+        ],
+        "memberships": [
+            {
+                "contactGroupMembership": {
+                    "contactGroupResourceName": "contactGroups/1",
+                },
+                "metadata": {"sourcePrimary": True},
+            }
+        ],
+        "externalIds": [
+            {"type": "amo_id", "value": "42", "metadata": {"verified": True}},
+        ],
+    }
+
+    sanitized = google_client.sanitize_person_for_update(person)
+
+    assert "metadata" not in sanitized
+    assert sanitized["phoneNumbers"] == [{"value": "+79990000000", "type": "mobile"}]
+    assert sanitized["emailAddresses"] == [{"value": "a@example.com", "type": "work"}]
+    assert sanitized["names"] == [{"displayName": "Alice Example", "givenName": "Alice"}]
+    assert sanitized["memberships"] == [
+        {"contactGroupMembership": {"contactGroupResourceName": "contactGroups/1"}}
+    ]
+    assert sanitized["externalIds"] == [{"type": "amo_id", "value": "42"}]

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -282,3 +282,97 @@ async def test_update_retries_on_missing_contact(monkeypatch, engine_env):
         engine.close()
 
     assert calls == ["people/missing"] * 4
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_phone_without_link_is_skipped(monkeypatch, engine_env):
+    module, _ = engine_env
+
+    one = make_candidate(
+        "people/1",
+        phones=["+79991234567"],
+        emails=[],
+        amo_id="10",
+        updated=datetime(2024, 4, 1, tzinfo=timezone.utc),
+    )
+    two = make_candidate(
+        "people/2",
+        phones=["+79991234567"],
+        emails=[],
+        amo_id="11",
+        updated=datetime(2024, 4, 2, tzinfo=timezone.utc),
+    )
+
+    async def fake_search(_keys):  # noqa: ANN001
+        return [one, two]
+
+    monkeypatch.setattr(module, "search_google_candidates", fake_search)
+
+    engine = SyncEngine()
+    try:
+        plan = await engine.plan(
+            {
+                "id": 99,
+                "name": "Ambiguous",
+                "phones": ["+7 999 123-45-67"],
+                "emails": [],
+                "ambiguous_phone_in_amo": True,
+            }
+        )
+    finally:
+        engine.close()
+
+    assert plan.action == "skip"
+    assert plan.reason == "ambiguous_phone_in_amo"
+
+
+@pytest.mark.asyncio
+async def test_merge_400_fallbacks_to_update(monkeypatch, engine_env):
+    module, _ = engine_env
+
+    primary = make_candidate(
+        "people/primary",
+        phones=["+15550001111"],
+        emails=[],
+        amo_id="5",
+        updated=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    duplicate = make_candidate(
+        "people/dup",
+        phones=["+15550001111"],
+        emails=[],
+        amo_id=None,
+        updated=datetime(2023, 12, 1, tzinfo=timezone.utc),
+    )
+
+    async def fake_search(_keys):  # noqa: ANN001
+        return [primary, duplicate]
+
+    class DummyResponse:
+        status_code = 400
+        text = "Invalid payload"
+
+    async def fake_merge(*args, **kwargs):  # noqa: ANN001
+        raise module.httpx.HTTPStatusError("bad", request=None, response=DummyResponse())
+
+    async def fake_update(resource_name, payload, *, update_person_fields, etag):  # noqa: ANN001
+        return {"resourceName": resource_name}
+
+    async def fake_get(resource_name, *, person_fields):  # noqa: ANN001
+        assert resource_name == "people/primary"
+        return primary.person
+
+    monkeypatch.setattr(module, "search_google_candidates", fake_search)
+    monkeypatch.setattr(module, "merge_contacts", fake_merge)
+    monkeypatch.setattr(module.google_client, "update_contact", fake_update)
+    monkeypatch.setattr(module.google_client, "get_contact", fake_get)
+
+    engine = SyncEngine()
+    try:
+        plan = await engine.plan({"id": 5, "name": "Bob", "phones": ["+1 555 000 1111"], "emails": []})
+        result = await engine.apply(plan)
+    finally:
+        engine.close()
+
+    assert result.action == "merged"
+    assert result.primary == "people/primary"


### PR DESCRIPTION
### Motivation
- Prevent Google People API `400 Bad Request` caused by sending read-only/service fields in merge/update payloads and avoid unsafe automatic merges in amoCRM when the same phone belongs to different `amo_id`s.
- Ensure merge operations are non-destructive on error and keep the overall sync flow healthy when Google returns validation errors.

### Description
- Add `sanitize_person_for_update(person: Mapping[str, Any]) -> Dict[str, Any]` in `app/integrations/google_client.py` and apply it before `update_contact` and `batch_update_contacts` so only writable top-level fields and allowed subfields (`phoneNumbers`, `emailAddresses`, `names`, `memberships`, `biographies`, `externalIds`, `clientData`, etc.) are sent to Google. 
- Sanitize merged payloads in `app/services/merge.py` after `union_fields`, remove propagation of `metadata` from `_merge_external_ids`, and add lifecycle logs (`merge.start`, `merge.primary_selected`, `merge.payload_sanitized`, `merge.updated`, `merge.deleted`).
- Stop copying read-only/service fields from source contacts in `app/services/transform.py` by removing `metadata`/`formattedType` propagation for phone/email entries so `union_fields` produces a clean payload.
- Implement ambiguous-phone protection and safer candidate selection: compute phone→amo_id mapping in `app/sync.py`, mark contacts with `ambiguous_phone_in_amo`, and in `app/services/sync_engine.py` prefer explicit mapping/externalId links and skip destructive merges when a phone is associated with multiple `amo_id`s (log `ambiguous_phone_in_amo`).
- Add merge-failure fallback in `app/services/sync_engine.py` that handles Google `400` during merge by logging `merge.failed` with `response_text`, performing a non-destructive update of the primary (`merge.fallback_update`), and avoiding deletion of duplicates on error.
- Update tests: add payload sanitization unit in `tests/test_google_client.py` and ambiguous-phone / merge-400 fallback tests in `tests/test_sync_engine.py`.

### Testing
- Ran `pytest -q tests/test_google_client.py tests/test_sync_engine.py` and all tests passed (12 passed). 
- Ran `pytest -q tests/test_match_service.py tests/test_apply.py` for related flows and they passed (14 passed). 
- The modified behavior is covered by the new and updated unit tests which assert sanitized payloads, ambiguous-phone skip, and merge-400 fallback to update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dad1cc24832796b7ad7238846919)