### PR TITLE
AGC-018: Google OAuth health monitoring and Telegram alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Available endpoints:
 | Endpoint | Description |
 | --- | --- |
 | `GET /debug/db` | Database connectivity and number of stored tokens |
-| `GET /debug/google` | Google token status: `has_token`, `expires_at`, `scopes` |
+| `GET /debug/google` | Google token + auth state: `auth_status`, `last_refresh_at`, `failure_count`, `last_failure_at`, `last_error` |
+| `GET /debug/status` | Aggregated operational state: `google_auth_status`, `worker_status`, `queue_status` |
 | `GET /debug/amo` | AmoCRM configuration: `base_url`, `auth_mode`, `is_ready` |
 | `GET /debug/config` | Snapshot of AmoCRM auth mode and whether the required secrets are present |
 | `GET /debug/ping-google` | Quick Google People API probe with latency and retry hints |
@@ -65,6 +66,41 @@ fields. When the service is rate limited it returns HTTP 200 with
 A missing/expired token yields HTTP 401 with the usual
 `{"detail": "Google auth required", "auth_url": "/auth/google/start"}`
 payload.
+
+## Google OAuth monitoring and Telegram alerts
+
+Google OAuth health is checked automatically every 60 minutes by the background
+worker. If token refresh fails, the service switches auth status to
+`needs_reauth` and sends one alert on state transition:
+
+```
+Google Contacts authorization failed.
+Нужно заново авторизоваться:
+https://amocrm-google-contacts-sync.onrender.com/auth/google/start
+```
+
+When authorization is restored, one recovery alert is sent:
+
+```
+Google Contacts authorization restored.
+Синхронизация снова работает.
+```
+
+Telegram notifications are configured purely via environment variables:
+
+* `TELEGRAM_BOT_TOKEN`
+* `TELEGRAM_CHAT_ID`
+
+If one of these variables is missing, notification sending is skipped and the
+service continues running.
+
+How to get `TELEGRAM_CHAT_ID`:
+1. Start a chat with your bot and send any message.
+2. Open `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/getUpdates`.
+3. Find `chat.id` in the response payload and use it as `TELEGRAM_CHAT_ID`.
+
+Manual re-authorization URL:
+`https://amocrm-google-contacts-sync.onrender.com/auth/google/start`.
 
 ## AmoCRM authentication
 

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,8 @@ class Settings:
     webhook_secret: str = os.getenv("WEBHOOK_SECRET", os.getenv("WEBHOOK_SHARED_SECRET", ""))
     debug_secret: str = os.getenv("DEBUG_SECRET", "")
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
+    telegram_bot_token: str = os.getenv("TELEGRAM_BOT_TOKEN", "")
+    telegram_chat_id: str = os.getenv("TELEGRAM_CHAT_ID", "")
 
 
 settings = Settings()

--- a/app/core/integration_state.py
+++ b/app/core/integration_state.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.storage import get_setting, set_settings
+
+AUTH_STATUS_OK = "ok"
+AUTH_STATUS_NEEDS_REAUTH = "needs_reauth"
+
+SETTING_AUTH_STATUS = "google_auth_status"
+SETTING_FAILURE_COUNT = "google_auth_failure_count"
+SETTING_LAST_REFRESH_AT = "google_last_refresh_at"
+SETTING_LAST_FAILURE_AT = "google_last_failure_at"
+SETTING_LAST_ERROR = "google_last_error"
+SETTING_LAST_ALERT_SENT_AT = "google_last_alert_sent_at"
+SETTING_LAST_RECOVERY_ALERT_SENT_AT = "google_last_recovery_alert_sent_at"
+
+
+@dataclass
+class GoogleIntegrationState:
+    auth_status: str
+    failure_count: int
+    last_refresh_at: Optional[datetime]
+    last_failure_at: Optional[datetime]
+    last_error: Optional[str]
+    last_alert_sent_at: Optional[datetime]
+    last_recovery_alert_sent_at: Optional[datetime]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _serialize_dt(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _parse_int(value: Optional[str], default: int = 0) -> int:
+    try:
+        return int(value or str(default))
+    except ValueError:
+        return default
+
+
+def get_google_integration_state(session) -> GoogleIntegrationState:
+    auth_status = get_setting(session, SETTING_AUTH_STATUS) or AUTH_STATUS_NEEDS_REAUTH
+    if auth_status not in {AUTH_STATUS_OK, AUTH_STATUS_NEEDS_REAUTH}:
+        auth_status = AUTH_STATUS_NEEDS_REAUTH
+    return GoogleIntegrationState(
+        auth_status=auth_status,
+        failure_count=_parse_int(get_setting(session, SETTING_FAILURE_COUNT), 0),
+        last_refresh_at=_parse_dt(get_setting(session, SETTING_LAST_REFRESH_AT)),
+        last_failure_at=_parse_dt(get_setting(session, SETTING_LAST_FAILURE_AT)),
+        last_error=get_setting(session, SETTING_LAST_ERROR),
+        last_alert_sent_at=_parse_dt(get_setting(session, SETTING_LAST_ALERT_SENT_AT)),
+        last_recovery_alert_sent_at=_parse_dt(get_setting(session, SETTING_LAST_RECOVERY_ALERT_SENT_AT)),
+    )
+
+
+def mark_google_auth_ok(session, now: Optional[datetime] = None) -> bool:
+    current = get_google_integration_state(session)
+    now = now or _utcnow()
+    set_settings(
+        session,
+        {
+            SETTING_AUTH_STATUS: AUTH_STATUS_OK,
+            SETTING_FAILURE_COUNT: "0",
+            SETTING_LAST_REFRESH_AT: _serialize_dt(now),
+            SETTING_LAST_ERROR: None,
+        },
+    )
+    return current.auth_status != AUTH_STATUS_OK
+
+
+def mark_google_auth_failure(session, error: str, now: Optional[datetime] = None) -> tuple[bool, int]:
+    current = get_google_integration_state(session)
+    now = now or _utcnow()
+    failures = max(0, current.failure_count) + 1
+    set_settings(
+        session,
+        {
+            SETTING_AUTH_STATUS: AUTH_STATUS_NEEDS_REAUTH,
+            SETTING_FAILURE_COUNT: str(failures),
+            SETTING_LAST_FAILURE_AT: _serialize_dt(now),
+            SETTING_LAST_ERROR: error,
+        },
+    )
+    changed = current.auth_status != AUTH_STATUS_NEEDS_REAUTH
+    return changed, failures
+
+
+def mark_google_alert_sent(session, now: Optional[datetime] = None) -> None:
+    set_settings(session, {SETTING_LAST_ALERT_SENT_AT: _serialize_dt(now or _utcnow())})
+
+
+def mark_google_recovery_alert_sent(session, now: Optional[datetime] = None) -> None:
+    set_settings(session, {SETTING_LAST_RECOVERY_ALERT_SENT_AT: _serialize_dt(now or _utcnow())})

--- a/app/debug.py
+++ b/app/debug.py
@@ -18,7 +18,8 @@ from app.google_auth import (
 )
 from app.google_people import GOOGLE_API_BASE
 from app.services.sync_engine import SyncEngine
-from app.storage import Token, get_session, get_token
+from app.storage import Token, get_pending_sync_stats, get_session, get_token
+from app.pending_sync_worker import pending_sync_worker
 from app.webhooks import get_recent_webhook_events
 
 router = APIRouter()
@@ -67,11 +68,14 @@ def debug_google(_=Depends(require_debug_secret)) -> dict[str, object]:
         state = get_google_auth_state(session)
         payload: dict[str, object] = {
             "auth_status": state.auth_status,
-            "last_refresh": state.last_refresh.isoformat().replace("+00:00", "Z")
-            if state.last_refresh
+            "last_refresh_at": state.last_refresh_at.isoformat().replace("+00:00", "Z")
+            if state.last_refresh_at
             else None,
             "expires_in": state.expires_in,
             "failure_count": state.failure_count,
+            "last_failure_at": state.last_failure_at.isoformat().replace("+00:00", "Z")
+            if state.last_failure_at
+            else None,
         }
         if state.last_error:
             payload["last_error"] = state.last_error
@@ -81,6 +85,20 @@ def debug_google(_=Depends(require_debug_secret)) -> dict[str, object]:
         expires = token.expiry.isoformat() if token.expiry else None
         payload.update({"has_token": True, "expires_at": expires, "scopes": token.scopes})
         return payload
+    finally:
+        session.close()
+
+
+@router.get("/status")
+def debug_status(_=Depends(require_debug_secret)) -> dict[str, object]:
+    session = get_session()
+    try:
+        google_state = get_google_auth_state(session)
+        return {
+            "google_auth_status": google_state.auth_status,
+            "worker_status": pending_sync_worker.get_status(),
+            "queue_status": get_pending_sync_stats(session),
+        }
     finally:
         session.close()
 

--- a/app/google_auth.py
+++ b/app/google_auth.py
@@ -12,7 +12,6 @@ import httpx
 from app.config import settings
 from app.core.integration_state import (
     AUTH_STATUS_NEEDS_REAUTH,
-    AUTH_STATUS_OK,
     GoogleIntegrationState,
     get_google_integration_state,
     mark_google_alert_sent,

--- a/app/google_auth.py
+++ b/app/google_auth.py
@@ -1,32 +1,31 @@
-"""Utilities for storing and refreshing Google OAuth tokens.
-
-This module provides a small abstraction around the token storage in the
-database.  The public function :func:`get_valid_google_access_token` returns a
-usable access token, refreshing it with Google if it is about to expire.  When
-refreshing fails or is impossible a :class:`GoogleAuthError` is raised so that
-callers can react appropriately (e.g. by asking the user to re-authorise).
-"""
+"""Utilities for storing and refreshing Google OAuth tokens."""
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Optional
 
 import httpx
 
 from app.config import settings
-from app.storage import Token, get_setting, get_token, save_token, set_settings
+from app.core.integration_state import (
+    AUTH_STATUS_NEEDS_REAUTH,
+    AUTH_STATUS_OK,
+    GoogleIntegrationState,
+    get_google_integration_state,
+    mark_google_alert_sent,
+    mark_google_auth_failure,
+    mark_google_auth_ok,
+    mark_google_recovery_alert_sent,
+)
+from app.integrations.telegram_client import send_telegram_alert, telegram_alerts_enabled
+from app.storage import Token, get_token, save_token
 
 
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-AUTH_STATUS_OK = "ok"
-AUTH_STATUS_NEEDS_REAUTH = "needs_reauth"
-SETTING_AUTH_STATUS = "google_auth_status"
-SETTING_LAST_REFRESH = "google_last_refresh"
-SETTING_REFRESH_FAILURES = "google_refresh_failures"
-SETTING_LAST_ERROR = "google_last_refresh_error"
+REAUTH_URL = "https://amocrm-google-contacts-sync.onrender.com/auth/google/start"
 
 logger = logging.getLogger(__name__)
 
@@ -39,41 +38,32 @@ class GoogleAuthError(Exception):
     auth_url: Optional[str] = None
 
 
-def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _serialize_dt(dt: datetime) -> str:
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _record_auth_ready(session, *, refreshed_at: Optional[datetime] = None) -> None:
-    refreshed_at = refreshed_at or _utcnow()
-    set_settings(
-        session,
-        {
-            SETTING_AUTH_STATUS: AUTH_STATUS_OK,
-            SETTING_LAST_REFRESH: _serialize_dt(refreshed_at),
-            SETTING_REFRESH_FAILURES: "0",
-            SETTING_LAST_ERROR: None,
-        },
-    )
+def _record_auth_ready(session, *, refreshed_at: Optional[datetime] = None) -> bool:
+    changed = mark_google_auth_ok(session, now=refreshed_at)
+    logger.info("google_auth.refresh_ok")
+    if changed:
+        logger.warning("google_auth.state_changed_to_ok")
+        send_telegram_alert(
+            "Google Contacts authorization restored.\n"
+            "Синхронизация снова работает."
+        )
+        if telegram_alerts_enabled():
+            mark_google_recovery_alert_sent(session)
+    return changed
 
 
 def _record_auth_failure(session, reason: str) -> int:
-    try:
-        failures = int(get_setting(session, SETTING_REFRESH_FAILURES) or "0")
-    except ValueError:
-        failures = 0
-    failures += 1
-    payload = {
-        SETTING_AUTH_STATUS: AUTH_STATUS_NEEDS_REAUTH,
-        SETTING_REFRESH_FAILURES: str(failures),
-        SETTING_LAST_ERROR: reason,
-    }
-    set_settings(session, payload)
+    changed, failures = mark_google_auth_failure(session, reason)
+    logger.warning("google_auth.refresh_failed reason=%s failure_count=%s", reason, failures)
+    if changed:
+        logger.error("google_auth.state_changed_to_needs_reauth")
+        send_telegram_alert(
+            "Google Contacts authorization failed.\n"
+            "Нужно заново авторизоваться:\n"
+            f"{REAUTH_URL}"
+        )
+        if telegram_alerts_enabled():
+            mark_google_alert_sent(session)
     return failures
 
 
@@ -83,7 +73,7 @@ async def _refresh_token(session) -> Token:
     token = get_token(session, "google")
     if not token or not token.refresh_token:
         _record_auth_failure(session, "refresh_unavailable")
-        raise GoogleAuthError("refresh_unavailable", "/auth/google/start")
+        raise GoogleAuthError("refresh_unavailable", REAUTH_URL)
 
     data = {
         "client_id": settings.google_client_id,
@@ -99,28 +89,22 @@ async def _refresh_token(session) -> Token:
         raise GoogleAuthError(f"network_error: {exc}")
 
     if resp.status_code != 200:
-        reason = f"http_{resp.status_code}"
-        failures = _record_auth_failure(session, reason)
-        if failures > 3:
-            logger.error(
-                "google.refresh_failed_repeatedly",
-                extra={"failures": failures, "status": resp.status_code},
-            )
-        raise GoogleAuthError("refresh_failed", "/auth/google/start")
+        _record_auth_failure(session, f"http_{resp.status_code}")
+        raise GoogleAuthError("refresh_failed", REAUTH_URL)
 
     payload = resp.json()
     access_token = payload.get("access_token")
     expires_in = payload.get("expires_in", 0)
     new_refresh = payload.get("refresh_token") or token.refresh_token
 
-    refresh_time = _utcnow()
+    refresh_time = datetime.utcnow()
     expiry = refresh_time + timedelta(seconds=int(expires_in))
     save_token(
         session,
         "google",
         access_token=access_token,
         refresh_token=new_refresh,
-        expiry=expiry.replace(tzinfo=None),
+        expiry=expiry,
         scopes=token.scopes or "",
         account_id=token.account_id,
     )
@@ -132,21 +116,14 @@ def _ensure_token(session) -> Token:
     token = get_token(session, "google")
     if not token:
         _record_auth_failure(session, "token_missing")
-        raise GoogleAuthError("token_missing", "/auth/google/start")
+        raise GoogleAuthError("token_missing", REAUTH_URL)
     if not token.refresh_token:
         _record_auth_failure(session, "refresh_unavailable")
-        raise GoogleAuthError("refresh_unavailable", "/auth/google/start")
+        raise GoogleAuthError("refresh_unavailable", REAUTH_URL)
     return token
 
 
 async def get_valid_google_access_token(session, *, force_refresh: bool = False) -> str:
-    """Return a valid access token for Google APIs.
-
-    If the current token is close to expiring (within 60 seconds) it is
-    refreshed automatically.  :class:`GoogleAuthError` is raised when the token
-    is missing or cannot be refreshed.
-    """
-
     token = _ensure_token(session)
 
     now = datetime.utcnow()
@@ -158,12 +135,6 @@ async def get_valid_google_access_token(session, *, force_refresh: bool = False)
 
 
 async def force_refresh_google_access_token(session) -> str:
-    """Force refresh and return a new access token.
-
-    This is used when Google API reports that the current token is invalid even
-    if it hasn't expired yet.
-    """
-
     token = await _refresh_token(session)
     return token.access_token
 
@@ -171,46 +142,37 @@ async def force_refresh_google_access_token(session) -> str:
 @dataclass
 class GoogleAuthState:
     auth_status: str
-    last_refresh: Optional[datetime]
+    last_refresh_at: Optional[datetime]
     expires_in: Optional[int]
     failure_count: int
+    last_failure_at: Optional[datetime]
     last_error: Optional[str]
+    last_alert_sent_at: Optional[datetime]
+    last_recovery_alert_sent_at: Optional[datetime]
 
 
 def get_google_auth_state(session) -> GoogleAuthState:
     token = get_token(session, "google")
-    status = get_setting(session, SETTING_AUTH_STATUS) or AUTH_STATUS_NEEDS_REAUTH
-    if status not in {AUTH_STATUS_OK, AUTH_STATUS_NEEDS_REAUTH}:
-        status = AUTH_STATUS_NEEDS_REAUTH
-
-    last_refresh_raw = get_setting(session, SETTING_LAST_REFRESH)
-    last_refresh: Optional[datetime] = None
-    if last_refresh_raw:
-        try:
-            last_refresh = datetime.fromisoformat(last_refresh_raw.replace("Z", "+00:00"))
-        except ValueError:
-            last_refresh = None
+    integration_state: GoogleIntegrationState = get_google_integration_state(session)
 
     expires_in: Optional[int] = None
     if token and token.expiry:
         delta = int((token.expiry - datetime.utcnow()).total_seconds())
         expires_in = delta if delta >= 0 else 0
 
-    try:
-        failures = int(get_setting(session, SETTING_REFRESH_FAILURES) or "0")
-    except ValueError:
-        failures = 0
-    last_error = get_setting(session, SETTING_LAST_ERROR)
-
+    status = integration_state.auth_status
     if not token or not token.refresh_token:
         status = AUTH_STATUS_NEEDS_REAUTH
 
     return GoogleAuthState(
         auth_status=status,
-        last_refresh=last_refresh,
+        last_refresh_at=integration_state.last_refresh_at,
         expires_in=expires_in,
-        failure_count=failures,
-        last_error=last_error,
+        failure_count=integration_state.failure_count,
+        last_failure_at=integration_state.last_failure_at,
+        last_error=integration_state.last_error,
+        last_alert_sent_at=integration_state.last_alert_sent_at,
+        last_recovery_alert_sent_at=integration_state.last_recovery_alert_sent_at,
     )
 
 
@@ -221,4 +183,3 @@ def google_auth_needs_reauth(session) -> bool:
 
 def mark_google_auth_ready(session) -> None:
     _record_auth_ready(session)
-

--- a/app/integrations/telegram_client.py
+++ b/app/integrations/telegram_client.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def telegram_alerts_enabled() -> bool:
+    return bool(settings.telegram_bot_token and settings.telegram_chat_id)
+
+
+def send_telegram_alert(message: str) -> None:
+    if not telegram_alerts_enabled():
+        logger.info("telegram_alert.skipped_not_configured")
+        return
+
+    url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/sendMessage"
+    payload = {
+        "chat_id": settings.telegram_chat_id,
+        "text": message,
+    }
+    try:
+        response = httpx.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+    except Exception as exc:  # pragma: no cover - network path
+        logger.warning("telegram_alert.failed error=%s", exc)
+        return
+
+    logger.info("telegram_alert.sent")

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from app.debug import router as debug_router
 from app.google_auth import get_google_auth_state
 from app.routes.sync import router as sync_router
 from app.pending_sync_worker import pending_sync_worker
-from app.storage import get_session, init_db
+from app.storage import get_pending_sync_stats, get_session, init_db
 from app.webhooks import router as webhook_router
 
 logger = logging.getLogger(__name__)
@@ -53,12 +53,14 @@ def create_app() -> FastAPI:
         session = get_session()
         try:
             state = get_google_auth_state(session)
+            queue_stats = get_pending_sync_stats(session)
             return {
-                "auth_status": state.auth_status,
-                "last_refresh": state.last_refresh.isoformat().replace("+00:00", "Z")
-                if state.last_refresh
+                "google_auth_status": state.auth_status,
+                "worker_status": pending_sync_worker.get_status(),
+                "queue_status": queue_stats,
+                "last_refresh_at": state.last_refresh_at.isoformat().replace("+00:00", "Z")
+                if state.last_refresh_at
                 else None,
-                "expires_in": state.expires_in,
                 "failure_count": state.failure_count,
             }
         finally:

--- a/app/pending_sync_worker.py
+++ b/app/pending_sync_worker.py
@@ -31,6 +31,7 @@ class PendingSyncWorker:
         self._lock: asyncio.Lock | None = None
         self._stopping = False
         self._refresh_task: asyncio.Task | None = None
+        self._auth_blocked_logged = False
 
     def start(self) -> None:
         if self._task and not self._task.done():
@@ -39,6 +40,7 @@ class PendingSyncWorker:
         self._wake_event = asyncio.Event()
         self._lock = asyncio.Lock()
         self._stopping = False
+        self._auth_blocked_logged = False
         self._task = loop.create_task(self._run())
         self._refresh_task = loop.create_task(self._refresh_loop())
         logger.info("pending_sync.worker_started")
@@ -106,8 +108,11 @@ class PendingSyncWorker:
             session = get_session()
             try:
                 if google_auth_needs_reauth(session):
-                    logger.warning("Skipping sync: Google authorization required")
+                    if not self._auth_blocked_logged:
+                        logger.warning("Google authorization required, sync postponed")
+                        self._auth_blocked_logged = True
                     return 0
+                self._auth_blocked_logged = False
                 records = fetch_due_pending_sync(session, limit)
                 processed = 0
                 for record in records:
@@ -118,7 +123,7 @@ class PendingSyncWorker:
                 session.close()
 
     async def _refresh_loop(self) -> None:
-        interval = 12 * 60 * 60
+        interval = 60 * 60
         try:
             while not self._stopping:
                 session = get_session()
@@ -127,11 +132,11 @@ class PendingSyncWorker:
                         await get_valid_google_access_token(session, force_refresh=True)
                     except GoogleAuthError as exc:
                         logger.warning(
-                            "google.token_refresh_failed reason=%s",
+                            "google_auth.refresh_failed reason=%s",
                             exc.reason,
                         )
                     else:
-                        logger.info("google.token_refreshed")
+                        logger.info("google_auth.refresh_ok")
                 finally:
                     session.close()
                 for _ in range(interval // 60):
@@ -238,6 +243,16 @@ class PendingSyncWorker:
         cap = 1800
         delay = base * (2 ** max(0, attempt - 1))
         return min(cap, delay)
+
+    def get_status(self) -> dict[str, object]:
+        running = bool(self._task and not self._task.done())
+        refresh_running = bool(self._refresh_task and not self._refresh_task.done())
+        return {
+            "running": running,
+            "refresh_loop_running": refresh_running,
+            "stopping": self._stopping,
+            "auth_blocked": self._auth_blocked_logged,
+        }
 
 
 def enqueue_contact(contact_id: int) -> None:

--- a/app/storage.py
+++ b/app/storage.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     DateTime,
     Integer,
     String,
+    func,
     create_engine,
     select,
 )
@@ -213,3 +214,11 @@ def fetch_due_pending_sync(session, limit: int) -> list[PendingSync]:
         .limit(limit)
     )
     return session.execute(stmt).scalars().all()
+
+
+def get_pending_sync_stats(session) -> dict[str, int]:
+    total_stmt = select(func.count(PendingSync.id))
+    due_stmt = select(func.count(PendingSync.id)).where(PendingSync.next_attempt_at <= datetime.utcnow())
+    total = int(session.execute(total_stmt).scalar_one() or 0)
+    due = int(session.execute(due_stmt).scalar_one() or 0)
+    return {"total": total, "due": due}

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -92,6 +92,17 @@ def test_debug_db_query_token(monkeypatch):
         assert resp.json()["db"] == "ok"
 
 
+def test_debug_status_endpoint(monkeypatch):
+    app = _create_app(monkeypatch, "secret")
+    with TestClient(app) as client:
+        resp = client.get("/debug/status", headers={"X-Debug-Secret": "secret"})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert "google_auth_status" in payload
+    assert "worker_status" in payload
+    assert "queue_status" in payload
+
+
 def test_debug_config_reports_auth(monkeypatch):
     _configure_amo(monkeypatch, mode="api_key", secret="api-key", base_url="https://amo.example")
     app = _create_app(monkeypatch, "secret")
@@ -438,4 +449,3 @@ def test_ping_google_profile_scope_regression(monkeypatch):
     assert payload["scopes_ok"] is True
     assert payload["can_read_connections"] is True
     assert payload["can_write_contact"] is True
-

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -10,8 +10,9 @@ from app.google_auth import (
     GoogleAuthError,
     get_google_auth_state,
     get_valid_google_access_token,
+    mark_google_auth_ready,
 )
-from app.storage import Token, get_session, init_db, save_token
+from app.storage import Setting, Token, get_session, init_db, save_token
 
 
 class DummyResponse:
@@ -28,11 +29,18 @@ class DummyResponse:
             raise httpx.HTTPStatusError("err", request=None, response=self)
 
 
+def _reset_google_settings(session) -> None:
+    session.query(Setting).filter(Setting.key.like("google_%")).delete(synchronize_session=False)
+    session.commit()
+
+
 def test_token_refresh(monkeypatch):
     init_db()
     session = get_session()
+    _reset_google_settings(session)
     expiry = datetime.utcnow() - timedelta(seconds=10)
     save_token(session, "google", "old", "refresh", expiry, scopes="")
+    mark_google_auth_ready(session)
 
     def fake_post(url, data, timeout):  # noqa: ARG001
         return DummyResponse(200, {"access_token": "new", "expires_in": 3600})
@@ -54,8 +62,10 @@ def test_token_refresh(monkeypatch):
 def test_refresh_failure_marks_needs_reauth(monkeypatch):
     init_db()
     session = get_session()
+    _reset_google_settings(session)
     expiry = datetime.utcnow() - timedelta(seconds=10)
     save_token(session, "google", "old", "refresh", expiry, scopes="")
+    mark_google_auth_ready(session)
 
     def fake_post(url, data, timeout):  # noqa: ARG001
         return DummyResponse(400)
@@ -67,6 +77,76 @@ def test_refresh_failure_marks_needs_reauth(monkeypatch):
 
     state = get_google_auth_state(session)
     assert state.auth_status == "needs_reauth"
+    assert state.failure_count == 1
+    assert state.last_failure_at is not None
+    session.close()
+
+
+def test_refresh_failure_alert_sent_once_on_state_change(monkeypatch):
+    init_db()
+    session = get_session()
+    _reset_google_settings(session)
+    expiry = datetime.utcnow() - timedelta(seconds=10)
+    save_token(session, "google", "old", "refresh", expiry, scopes="")
+    mark_google_auth_ready(session)
+
+    sent: list[str] = []
+
+    def fake_send(message: str) -> None:
+        sent.append(message)
+
+    def fake_post(url, data, timeout):  # noqa: ARG001
+        return DummyResponse(400)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr("app.google_auth.send_telegram_alert", fake_send)
+
+    with pytest.raises(GoogleAuthError):
+        asyncio.run(get_valid_google_access_token(session))
+    with pytest.raises(GoogleAuthError):
+        asyncio.run(get_valid_google_access_token(session))
+
+    state = get_google_auth_state(session)
+    assert state.auth_status == "needs_reauth"
+    assert state.failure_count == 2
+    assert len(sent) == 1
+    session.close()
+
+
+def test_refresh_success_after_failure_sends_recovery_once(monkeypatch):
+    init_db()
+    session = get_session()
+    _reset_google_settings(session)
+    expiry = datetime.utcnow() - timedelta(seconds=10)
+    save_token(session, "google", "old", "refresh", expiry, scopes="")
+    mark_google_auth_ready(session)
+
+    sent: list[str] = []
+
+    def fake_send(message: str) -> None:
+        sent.append(message)
+
+    def fail_post(url, data, timeout):  # noqa: ARG001
+        return DummyResponse(400)
+
+    def ok_post(url, data, timeout):  # noqa: ARG001
+        return DummyResponse(200, {"access_token": "new", "expires_in": 3600})
+
+    monkeypatch.setattr("app.google_auth.send_telegram_alert", fake_send)
+    monkeypatch.setattr(httpx, "post", fail_post)
+    with pytest.raises(GoogleAuthError):
+        asyncio.run(get_valid_google_access_token(session))
+
+    monkeypatch.setattr(httpx, "post", ok_post)
+    token = asyncio.run(get_valid_google_access_token(session))
+    assert token == "new"
+
+    state = get_google_auth_state(session)
+    assert state.auth_status == "ok"
+    assert state.failure_count == 0
+    assert len(sent) == 2
+    assert "failed" in sent[0]
+    assert "restored" in sent[1]
     session.close()
 
 
@@ -128,6 +208,7 @@ def test_people_client_retries(monkeypatch):
 async def test_google_callback_reuses_refresh_token(monkeypatch):
     init_db()
     base_session = get_session()
+    _reset_google_settings(base_session)
     base_session.query(Token).delete()
     base_session.commit()
     save_token(base_session, "google", "old", "refresh", None, scopes="")
@@ -180,4 +261,3 @@ async def test_google_callback_reuses_refresh_token(monkeypatch):
     state = get_google_auth_state(session)
     assert state.auth_status == "ok"
     session.close()
-


### PR DESCRIPTION
### Motivation
- Automatically detect Google OAuth refresh failures and notify an administrator to avoid manual log inspection and prolonged sync outages. 
- Prevent repetitive error spam from the worker when Google authorization is invalid and provide a single clear alert on state change. 
- Expose concise operational status endpoints for easier on-call diagnostics and to surface Google auth state to monitoring. 

### Description
- Introduced a persistent Google integration state service backed by the existing `settings` table (`auth_status`, `failure_count`, `last_refresh_at`, `last_failure_at`, `last_error`, `last_alert_sent_at`, `last_recovery_alert_sent_at`) in `app/core/integration_state.py`. 
- Added a lightweight Telegram helper `app/integrations/telegram_client.py` and config keys in `app/config.py` to send `sendMessage` alerts when both `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are set, with safe logging on failures. 
- Reworked `app/google_auth.py` to update the integration state on refresh success/failure, emit new structured logs (`google_auth.refresh_ok`, `google_auth.refresh_failed`, `google_auth.state_changed_to_needs_reauth`, `google_auth.state_changed_to_ok`), and send alerts only on state transitions (`ok -> needs_reauth`, `needs_reauth -> ok`) with a reauth link. 
- Updated the pending sync worker (`app/pending_sync_worker.py`) to run forced token refresh every 60 minutes, suppress repetitive auth-required log spam while blocked, and expose `get_status()` for diagnostic endpoints. 
- Added queue stats helper in `app/storage.py`, extended debug endpoints (`/debug/google`, new `/debug/status`) and public `/status` to include `google_auth_status`, `worker_status`, and `queue_status`, and documented behavior and Telegram setup in `README.md`. 
- Added and updated unit tests covering state transitions and alert behavior and adjusted existing tests to reset integration state where needed. 

### Testing
- Ran the targeted unit tests `tests/test_google.py`, `tests/test_debug.py`, and `tests/test_pending_sync_worker.py`, and they all passed (`22 passed`); warnings are informational only. 
- New tests validate: refresh success sets `auth_status=ok`, refresh failures set `auth_status=needs_reauth` and increment `failure_count`, alerts are sent once on state transitions, and recovery alert is sent once after successful reauth. 
- Manual inspection and logs were used to verify that missing Telegram env vars skip sending without crashing and that the worker suppresses repeated auth error spam.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f501a3f88327b393291e5bd256d5)