### PR TITLE
Fix pending-sync shutdown DB errors and improve queue traceability

### DIFF
--- a/app/debug.py
+++ b/app/debug.py
@@ -18,7 +18,14 @@ from app.google_auth import (
 )
 from app.google_people import GOOGLE_API_BASE
 from app.services.sync_engine import SyncEngine
-from app.storage import Token, get_pending_sync_stats, get_session, get_token
+from app.storage import (
+    Token,
+    get_pending_sync_stats,
+    get_session,
+    get_token,
+    list_pending_sync_by_contact_id,
+    list_recent_pending_sync,
+)
 from app.pending_sync_worker import pending_sync_worker
 from app.webhooks import get_recent_webhook_events
 
@@ -99,6 +106,50 @@ def debug_status(_=Depends(require_debug_secret)) -> dict[str, object]:
             "worker_status": pending_sync_worker.get_status(),
             "queue_status": get_pending_sync_stats(session),
         }
+    finally:
+        session.close()
+
+
+def _serialize_pending_record(record) -> dict[str, object]:
+    return {
+        "record_id": record.id,
+        "contact_id": record.amo_contact_id,
+        "attempts": record.attempts,
+        "last_error": record.last_error,
+        "status": "retry" if record.last_error else "pending",
+        "created_at": record.created_at.isoformat() if record.created_at else None,
+        "updated_at": record.updated_at.isoformat() if record.updated_at else None,
+        "next_attempt_at": record.next_attempt_at.isoformat() if record.next_attempt_at else None,
+    }
+
+
+@router.get("/pending-sync")
+def debug_pending_sync(
+    contact_id: int = Query(..., ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    _=Depends(require_debug_secret),
+) -> dict[str, object]:
+    session = get_session()
+    try:
+        rows = list_pending_sync_by_contact_id(session, contact_id, limit=limit)
+        return {
+            "contact_id": contact_id,
+            "count": len(rows),
+            "items": [_serialize_pending_record(row) for row in rows],
+        }
+    finally:
+        session.close()
+
+
+@router.get("/pending-sync/recent")
+def debug_pending_sync_recent(
+    limit: int = Query(20, ge=1, le=100),
+    _=Depends(require_debug_secret),
+) -> dict[str, object]:
+    session = get_session()
+    try:
+        rows = list_recent_pending_sync(session, limit=limit)
+        return {"count": len(rows), "items": [_serialize_pending_record(row) for row in rows]}
     finally:
         session.close()
 

--- a/app/pending_sync_worker.py
+++ b/app/pending_sync_worker.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import datetime, timedelta
 from typing import Optional
 
 from loguru import logger
+from sqlalchemy.exc import OperationalError
 
 from app.amocrm import extract_name_and_fields, get_contact
 from app.google_auth import (
@@ -85,6 +87,8 @@ class PendingSyncWorker:
     async def _run(self) -> None:
         try:
             while not self._stopping:
+                if self._stopping:
+                    break
                 processed = await self._process_due(self.batch_size)
                 if processed:
                     await asyncio.sleep(0)
@@ -113,20 +117,31 @@ class PendingSyncWorker:
         if self._lock is None:
             self._lock = lock
         async with lock:
+            if self._stopping and enforce_auth_block:
+                return 0
             session = get_session()
             try:
-                if enforce_auth_block and google_auth_needs_reauth(session):
+                if enforce_auth_block and not self._stopping and google_auth_needs_reauth(session):
                     if not self._auth_blocked_logged:
                         logger.warning("Google authorization required, sync postponed")
                         self._auth_blocked_logged = True
                     return 0
                 self._auth_blocked_logged = False
+                if self._stopping and enforce_auth_block:
+                    return 0
                 records = fetch_due_pending_sync(session, limit)
                 processed = 0
                 for record in records:
+                    if self._stopping and enforce_auth_block:
+                        break
                     await self._handle_record(session, record)
                     processed += 1
                 return processed
+            except OperationalError:
+                if self._stopping:
+                    logger.warning("shutdown.db_error_suppressed")
+                    return 0
+                raise
             finally:
                 session.close()
 
@@ -163,7 +178,13 @@ class PendingSyncWorker:
 
     async def _handle_record(self, session, record: PendingSync) -> None:
         contact_id = int(record.amo_contact_id)
-        logger.debug("pending_sync.process", contact_id=contact_id, attempts=record.attempts)
+        start = time.perf_counter()
+        logger.info(
+            "pending_sync.process",
+            record_id=record.id,
+            contact_id=contact_id,
+            attempt=record.attempts + 1,
+        )
         engine = SyncEngine()
         try:
             contact_data = await get_contact(contact_id)
@@ -176,6 +197,7 @@ class PendingSyncWorker:
             self._schedule_retry(session, record, delay, "google_rate_limit")
             logger.warning(
                 "pending_sync.retry_rate_limit",
+                record_id=record.id,
                 contact_id=contact_id,
                 delay=delay,
                 attempts=record.attempts,
@@ -191,6 +213,7 @@ class PendingSyncWorker:
                 )
                 logger.error(
                     "pending_sync.dead_letter",
+                    record_id=record.id,
                     contact_id=contact_id,
                     reason="amo_auth_missing",
                     detail=message,
@@ -200,22 +223,28 @@ class PendingSyncWorker:
         except Exception as exc:  # pragma: no cover - defensive logging
             delay = self._retry_delay(record.attempts + 1)
             self._schedule_retry(session, record, delay, exc.__class__.__name__)
-            logger.exception(
+            logger.warning(
                 "pending_sync.retry_error",
+                record_id=record.id,
                 contact_id=contact_id,
                 attempts=record.attempts,
+                error_class=exc.__class__.__name__,
+                reason=str(exc)[:200],
             )
         else:
             resource_name = result.resource_name if hasattr(result, "resource_name") else None
+            action = getattr(result, "action", None)
             if resource_name:
                 save_link(session, str(contact_id), resource_name)
             session.delete(record)
             session.commit()
             logger.info(
                 "pending_sync.synced",
+                record_id=record.id,
                 contact_id=contact_id,
                 resource_name=resource_name,
-                action=getattr(result, "action", None),
+                action=action,
+                duration_ms=max(1, int((time.perf_counter() - start) * 1000)),
             )
         finally:
             engine.close()
@@ -263,10 +292,11 @@ class PendingSyncWorker:
         }
 
 
-def enqueue_contact(contact_id: int) -> None:
+def enqueue_contact(contact_id: int) -> int:
     session = get_session()
     try:
-        enqueue_pending_sync(session, contact_id)
+        record = enqueue_pending_sync(session, contact_id)
+        return int(record.id)
     finally:
         session.close()
 

--- a/app/storage.py
+++ b/app/storage.py
@@ -22,7 +22,12 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False)
 def get_engine():
     global engine
     if engine is None:
-        engine = create_engine(settings.db_url, future=True)
+        engine = create_engine(
+            settings.db_url,
+            future=True,
+            pool_pre_ping=True,
+            pool_recycle=300,
+        )
         SessionLocal.configure(bind=engine)
     return engine
 
@@ -211,6 +216,27 @@ def fetch_due_pending_sync(session, limit: int) -> list[PendingSync]:
         select(PendingSync)
         .where(PendingSync.next_attempt_at <= datetime.utcnow())
         .order_by(PendingSync.next_attempt_at, PendingSync.id)
+        .limit(limit)
+    )
+    return session.execute(stmt).scalars().all()
+
+
+def list_pending_sync_by_contact_id(
+    session, contact_id: int, limit: int = 50
+) -> list[PendingSync]:
+    stmt = (
+        select(PendingSync)
+        .where(PendingSync.amo_contact_id == contact_id)
+        .order_by(PendingSync.updated_at.desc(), PendingSync.id.desc())
+        .limit(limit)
+    )
+    return session.execute(stmt).scalars().all()
+
+
+def list_recent_pending_sync(session, limit: int = 50) -> list[PendingSync]:
+    stmt = (
+        select(PendingSync)
+        .order_by(PendingSync.updated_at.desc(), PendingSync.id.desc())
         .limit(limit)
     )
     return session.execute(stmt).scalars().all()

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -25,6 +25,7 @@ def _record_webhook_event(event: str, contact_id: int) -> None:
             "ts": datetime.now(timezone.utc).isoformat(),
             "event": event,
             "contact_id": contact_id,
+            "record_id": None,
         }
     )
 
@@ -181,10 +182,11 @@ async def webhook_amo(
     queued: List[int] = []
     event_payload: Dict[str, Any] = payload if parsed_source == "json" else {}
     for contact_id in sorted(contact_ids):
-        enqueue_contact(contact_id)
+        record_id = enqueue_contact(contact_id)
         queued.append(contact_id)
+        logger.info("webhook.queued", record_id=record_id, contact_id=contact_id, event=_guess_event_name(event_payload, contact_id))
         _record_webhook_event(_guess_event_name(event_payload, contact_id), contact_id)
 
-    logger.info("webhook.queued", count=len(queued), ids=queued)
+    logger.info("webhook.queued_batch", count=len(queued), ids=queued)
     pending_sync_worker.wake()
     return JSONResponse(content={"queued": queued})


### PR DESCRIPTION
### Motivation
- Prevent worker crashes during shutdown caused by DB/SSL connection errors and make queued-contact processing fully observable end-to-end.
- Ensure the worker stops scheduling new DB/API work once stop is requested so shutdown is clean and deterministic.
- Provide tools to inspect the fate of a specific amo contact_id from webhook -> queued -> processed flows.

### Description
- Hardened `PendingSyncWorker` to avoid starting new DB/API work after `stop()` is requested and added early-stop checks in `_run()`/`_process_due()` so the background loop finishes safely without new selects/updates.
- Suppressed `OperationalError` during shutdown and emit a short warning `shutdown.db_error_suppressed` instead of letting an SSL/DB traceback abort shutdown.
- Enabled SQLAlchemy engine keepalive options (`pool_pre_ping=True`, `pool_recycle=300`) to reduce transient SSL/connection failures. (`app/storage.py`)
- Improved logging and record-level traceability: `enqueue_contact()` now returns `record_id`; webhook logs per-contact `webhook.queued` with `record_id/contact_id/event` and `webhook.queued_batch` for the batch; worker logs `pending_sync.process`/`pending_sync.synced`/`pending_sync.retry_error` include `record_id`, `contact_id`, `attempt`, `action`, `resource_name`, `duration_ms`, and concise error info. (`app/webhooks.py`, `app/pending_sync_worker.py`)
- Added storage helper queries `list_pending_sync_by_contact_id()` and `list_recent_pending_sync()` and new debug endpoints `GET /debug/pending-sync?contact_id=...` and `GET /debug/pending-sync/recent` that return serialized pending/retry rows for quick diagnostics. (`app/storage.py`, `app/debug.py`)

### Testing
- Ran `pytest -q tests/test_webhook.py::test_webhook_enqueues_and_processes` and it passed.
- Ran `pytest -q tests/test_webhook.py::test_webhook_supports_legacy_payload` and it passed.
- Ran `pytest -q tests/test_debug.py::test_debug_status_endpoint` and it passed.
- The three targeted tests completed successfully (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024223929883278f215eb308a697f9)