### PR TITLE
AGC-021: Normalize Telegram alerts — actionable Russian notifications, grace window and standardized format

### DIFF
--- a/app/alerts.py
+++ b/app/alerts.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from loguru import logger
+
+from app.config import settings
+from app.integrations.telegram_client import send_telegram_alert
+
+
+class AlertCategory(str, Enum):
+    GOOGLE_AUTH_REAUTH_REQUIRED = "google_auth_reauth_required"
+    PROCESSING_LOOP_STALLED_UNRECOVERED = "processing_loop_stalled_unrecovered"
+    QUEUE_BACKLOG_UNRECOVERED = "queue_backlog_unrecovered"
+    SERVICE_MANUAL_RESTART_RECOMMENDED = "service_manual_restart_recommended"
+
+
+@dataclass(frozen=True)
+class AlertTemplate:
+    title: str
+    requires_manual_action: bool
+    action_text: str
+    action_url: Optional[str]
+    recovery_message_enabled: bool = True
+
+
+def _dashboard_url() -> Optional[str]:
+    return settings.render_service_dashboard_url or None
+
+
+def _templates() -> dict[AlertCategory, AlertTemplate]:
+    dashboard_url = _dashboard_url()
+    return {
+        AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED: AlertTemplate(
+            title="Потеряна авторизация Google Contacts",
+            requires_manual_action=True,
+            action_text="Перейдите по ссылке и заново авторизуйте Google Contacts",
+            action_url="https://amocrm-google-contacts-sync.onrender.com/auth/google/start",
+        ),
+        AlertCategory.PROCESSING_LOOP_STALLED_UNRECOVERED: AlertTemplate(
+            title="Очередь синхронизации не обрабатывается",
+            requires_manual_action=True,
+            action_text="Проверьте Render logs и при необходимости перезапустите сервис",
+            action_url=dashboard_url,
+        ),
+        AlertCategory.QUEUE_BACKLOG_UNRECOVERED: AlertTemplate(
+            title="Накопилась необрабатываемая очередь синхронизации",
+            requires_manual_action=True,
+            action_text="Проверьте состояние очереди и перезапустите сервис при необходимости",
+            action_url=dashboard_url,
+        ),
+        AlertCategory.SERVICE_MANUAL_RESTART_RECOMMENDED: AlertTemplate(
+            title="Рекомендуется ручной перезапуск сервиса",
+            requires_manual_action=True,
+            action_text="Откройте Render dashboard, проверьте логи и выполните restart",
+            action_url=dashboard_url,
+        ),
+    }
+
+
+def _build_message(*, service_name: str, problem: str, status: str, action_text: str, action_url: Optional[str], technical: Optional[str] = None) -> str:
+    parts = [
+        f"Сервис: {service_name}",
+        f"Проблема: {problem}",
+        f"Статус: {status}",
+        f"Что делать: {action_text}",
+    ]
+    if action_url:
+        parts.append(f"Ссылка: {action_url}")
+    if technical:
+        parts.append(f"Технически: {technical}")
+    return "\n".join(parts)
+
+
+def send_problem_alert(category: AlertCategory, *, technical: Optional[str] = None) -> None:
+    tpl = _templates()[category]
+    status = "Нужно ручное действие" if tpl.requires_manual_action else "Нужно внимание"
+    if not tpl.action_url and "Render" in tpl.action_text:
+        action_text = "Проверьте сервис в Render dashboard"
+    else:
+        action_text = tpl.action_text
+    message = _build_message(
+        service_name=settings.service_display_name,
+        problem=tpl.title,
+        status=status,
+        action_text=action_text,
+        action_url=tpl.action_url,
+        technical=technical,
+    )
+    send_telegram_alert(message)
+    logger.info("telegram_alert.sent_manual_action_required category=%s", category.value)
+
+
+def send_recovery_alert(category: AlertCategory, *, technical: Optional[str] = None) -> None:
+    tpl = _templates()[category]
+    if not tpl.recovery_message_enabled:
+        return
+    message = _build_message(
+        service_name=settings.service_display_name,
+        problem=tpl.title,
+        status="Восстановлено",
+        action_text="Действий не требуется",
+        action_url=None,
+        technical=technical,
+    )
+    send_telegram_alert(message)
+    logger.info("telegram_alert.recovery_sent category=%s", category.value)

--- a/app/alerts.py
+++ b/app/alerts.py
@@ -74,7 +74,7 @@ def _build_message(*, service_name: str, problem: str, status: str, action_text:
     return "\n".join(parts)
 
 
-def send_problem_alert(category: AlertCategory, *, technical: Optional[str] = None) -> None:
+def send_problem_alert(category: AlertCategory, *, technical: Optional[str] = None) -> bool:
     tpl = _templates()[category]
     status = "Нужно ручное действие" if tpl.requires_manual_action else "Нужно внимание"
     if not tpl.action_url and "Render" in tpl.action_text:
@@ -89,14 +89,17 @@ def send_problem_alert(category: AlertCategory, *, technical: Optional[str] = No
         action_url=tpl.action_url,
         technical=technical,
     )
-    send_telegram_alert(message)
+    sent = send_telegram_alert(message)
+    if not sent:
+        return False
     logger.info("telegram_alert.sent_manual_action_required category=%s", category.value)
+    return True
 
 
-def send_recovery_alert(category: AlertCategory, *, technical: Optional[str] = None) -> None:
+def send_recovery_alert(category: AlertCategory, *, technical: Optional[str] = None) -> bool:
     tpl = _templates()[category]
     if not tpl.recovery_message_enabled:
-        return
+        return False
     message = _build_message(
         service_name=settings.service_display_name,
         problem=tpl.title,
@@ -105,5 +108,8 @@ def send_recovery_alert(category: AlertCategory, *, technical: Optional[str] = N
         action_url=None,
         technical=technical,
     )
-    send_telegram_alert(message)
+    sent = send_telegram_alert(message)
+    if not sent:
+        return False
     logger.info("telegram_alert.recovery_sent category=%s", category.value)
+    return True

--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,10 @@ class Settings:
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
     telegram_bot_token: str = os.getenv("TELEGRAM_BOT_TOKEN", "")
     telegram_chat_id: str = os.getenv("TELEGRAM_CHAT_ID", "")
+    alert_grace_seconds: int = int(os.getenv("ALERT_GRACE_SECONDS", "60"))
+    telegram_alert_language: str = os.getenv("TELEGRAM_ALERT_LANGUAGE", "ru")
+    service_display_name: str = os.getenv("SERVICE_DISPLAY_NAME", "AmoCRM Google Contacts Sync")
+    render_service_dashboard_url: str = os.getenv("RENDER_SERVICE_DASHBOARD_URL", "")
 
 
 settings = Settings()

--- a/app/google_auth.py
+++ b/app/google_auth.py
@@ -19,7 +19,7 @@ from app.core.integration_state import (
     mark_google_auth_ok,
     mark_google_recovery_alert_sent,
 )
-from app.integrations.telegram_client import send_telegram_alert, telegram_alerts_enabled
+from app.alerts import AlertCategory, send_problem_alert, send_recovery_alert
 from app.storage import Token, get_token, save_token
 
 
@@ -38,16 +38,16 @@ class GoogleAuthError(Exception):
 
 
 def _record_auth_ready(session, *, refreshed_at: Optional[datetime] = None) -> bool:
+    integration_state = get_google_integration_state(session)
     changed = mark_google_auth_ok(session, now=refreshed_at)
     logger.info("google_auth.refresh_ok")
     if changed:
         logger.warning("google_auth.state_changed_to_ok")
-        send_telegram_alert(
-            "Google Contacts authorization restored.\n"
-            "Синхронизация снова работает."
-        )
-        if telegram_alerts_enabled():
+        if integration_state.last_alert_sent_at:
+            send_recovery_alert(AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED, technical="google_auth_status=ok")
             mark_google_recovery_alert_sent(session)
+        else:
+            logger.info("telegram_alert.recovery_skipped_no_initial_alert category=google_auth_reauth_required")
     return changed
 
 
@@ -56,13 +56,8 @@ def _record_auth_failure(session, reason: str) -> int:
     logger.warning("google_auth.refresh_failed reason=%s failure_count=%s", reason, failures)
     if changed:
         logger.error("google_auth.state_changed_to_needs_reauth")
-        send_telegram_alert(
-            "Google Contacts authorization failed.\n"
-            "Нужно заново авторизоваться:\n"
-            f"{REAUTH_URL}"
-        )
-        if telegram_alerts_enabled():
-            mark_google_alert_sent(session)
+        send_problem_alert(AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED, technical=f"reason={reason}")
+        mark_google_alert_sent(session)
     return failures
 
 

--- a/app/google_auth.py
+++ b/app/google_auth.py
@@ -44,8 +44,9 @@ def _record_auth_ready(session, *, refreshed_at: Optional[datetime] = None) -> b
     if changed:
         logger.warning("google_auth.state_changed_to_ok")
         if integration_state.last_alert_sent_at:
-            send_recovery_alert(AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED, technical="google_auth_status=ok")
-            mark_google_recovery_alert_sent(session)
+            sent = send_recovery_alert(AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED, technical="google_auth_status=ok")
+            if sent:
+                mark_google_recovery_alert_sent(session)
         else:
             logger.info("telegram_alert.recovery_skipped_no_initial_alert category=google_auth_reauth_required")
     return changed
@@ -56,8 +57,9 @@ def _record_auth_failure(session, reason: str) -> int:
     logger.warning("google_auth.refresh_failed reason=%s failure_count=%s", reason, failures)
     if changed:
         logger.error("google_auth.state_changed_to_needs_reauth")
-        send_problem_alert(AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED, technical=f"reason={reason}")
-        mark_google_alert_sent(session)
+        sent = send_problem_alert(AlertCategory.GOOGLE_AUTH_REAUTH_REQUIRED, technical=f"reason={reason}")
+        if sent:
+            mark_google_alert_sent(session)
     return failures
 
 

--- a/app/integrations/telegram_client.py
+++ b/app/integrations/telegram_client.py
@@ -13,10 +13,10 @@ def telegram_alerts_enabled() -> bool:
     return bool(settings.telegram_bot_token and settings.telegram_chat_id)
 
 
-def send_telegram_alert(message: str) -> None:
+def send_telegram_alert(message: str) -> bool:
     if not telegram_alerts_enabled():
         logger.info("telegram_alert.skipped_not_configured")
-        return
+        return False
 
     url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/sendMessage"
     payload = {
@@ -28,6 +28,7 @@ def send_telegram_alert(message: str) -> None:
         response.raise_for_status()
     except Exception as exc:  # pragma: no cover - network path
         logger.warning("telegram_alert.failed error=%s", exc)
-        return
+        return False
 
     logger.info("telegram_alert.sent")
+    return True

--- a/app/pending_sync_worker.py
+++ b/app/pending_sync_worker.py
@@ -10,6 +10,8 @@ from loguru import logger
 from sqlalchemy.exc import OperationalError
 
 from app.amocrm import extract_name_and_fields, get_contact
+from app.alerts import AlertCategory, send_problem_alert, send_recovery_alert
+from app.config import settings
 from app.google_auth import (
     GoogleAuthError,
     get_valid_google_access_token,
@@ -25,7 +27,6 @@ from app.storage import (
     save_link,
 )
 from app.services.sync_engine import SyncEngine
-from app.integrations.telegram_client import send_telegram_alert
 
 
 class PendingSyncWorker:
@@ -48,6 +49,8 @@ class PendingSyncWorker:
         self.recovery_in_progress = False
         self.backlog_detected = False
         self._backlog_alert_sent = False
+        self._problem_detected_at: datetime | None = None
+        self._processing_alert_sent = False
         self._processing_loop_restart_count = 0
         self._processing_stall_seconds = 150
         self._processing_backlog_stall_seconds = 90
@@ -272,14 +275,28 @@ class PendingSyncWorker:
                 success_age,
                 pending_count,
             )
-            if pending_count > 0 and not self._backlog_alert_sent:
-                send_telegram_alert(
-                    "AmoCRM Google Contacts Sync: processing loop stalled.\n"
-                    f"Pending queue is not being processed.\nQueue pending count: {pending_count}\n"
-                    "Restart recommended or auto-recovery started."
+            if self._problem_detected_at is None:
+                self._problem_detected_at = now
+            elapsed = (now - self._problem_detected_at).total_seconds()
+            if elapsed >= settings.alert_grace_seconds and not self._processing_alert_sent:
+                category = (
+                    AlertCategory.QUEUE_BACKLOG_UNRECOVERED
+                    if pending_count > 0
+                    else AlertCategory.PROCESSING_LOOP_STALLED_UNRECOVERED
                 )
+                send_problem_alert(category, technical=f"pending_count={pending_count} heartbeat_age={heartbeat_age:.1f}")
+                self._processing_alert_sent = True
                 self._backlog_alert_sent = True
             await self._restart_processing_loop()
+        elif self._problem_detected_at is not None:
+            elapsed = (now - self._problem_detected_at).total_seconds()
+            if self._processing_alert_sent:
+                send_recovery_alert(AlertCategory.PROCESSING_LOOP_STALLED_UNRECOVERED, technical=f"pending_count={pending_count}")
+            else:
+                logger.info("telegram_alert.suppressed_auto_recovered elapsed=%.1f", elapsed)
+                logger.info("telegram_alert.recovery_skipped_no_initial_alert category=processing_loop_stalled_unrecovered")
+            self._problem_detected_at = None
+            self._processing_alert_sent = False
 
     async def _restart_processing_loop(self) -> None:
         if self.recovery_in_progress or self._stopping:
@@ -294,7 +311,6 @@ class PendingSyncWorker:
             self._task = loop.create_task(self._run())
             self._processing_loop_restart_count += 1
             logger.warning("pending_sync.processing_loop_restarted count=%s", self._processing_loop_restart_count)
-            send_telegram_alert("AmoCRM Google Contacts Sync: processing loop restored.\nQueue processing resumed.")
         finally:
             self.recovery_in_progress = False
 

--- a/app/pending_sync_worker.py
+++ b/app/pending_sync_worker.py
@@ -51,6 +51,7 @@ class PendingSyncWorker:
         self._backlog_alert_sent = False
         self._problem_detected_at: datetime | None = None
         self._processing_alert_sent = False
+        self._last_problem_alert_category: AlertCategory | None = None
         self._processing_loop_restart_count = 0
         self._processing_stall_seconds = 150
         self._processing_backlog_stall_seconds = 90
@@ -284,19 +285,22 @@ class PendingSyncWorker:
                     if pending_count > 0
                     else AlertCategory.PROCESSING_LOOP_STALLED_UNRECOVERED
                 )
-                send_problem_alert(category, technical=f"pending_count={pending_count} heartbeat_age={heartbeat_age:.1f}")
-                self._processing_alert_sent = True
-                self._backlog_alert_sent = True
+                sent = send_problem_alert(category, technical=f"pending_count={pending_count} heartbeat_age={heartbeat_age:.1f}")
+                if sent:
+                    self._processing_alert_sent = True
+                    self._backlog_alert_sent = True
+                    self._last_problem_alert_category = category
             await self._restart_processing_loop()
         elif self._problem_detected_at is not None:
             elapsed = (now - self._problem_detected_at).total_seconds()
-            if self._processing_alert_sent:
-                send_recovery_alert(AlertCategory.PROCESSING_LOOP_STALLED_UNRECOVERED, technical=f"pending_count={pending_count}")
+            if self._processing_alert_sent and self._last_problem_alert_category is not None:
+                send_recovery_alert(self._last_problem_alert_category, technical=f"pending_count={pending_count}")
             else:
                 logger.info("telegram_alert.suppressed_auto_recovered elapsed=%.1f", elapsed)
                 logger.info("telegram_alert.recovery_skipped_no_initial_alert category=processing_loop_stalled_unrecovered")
             self._problem_detected_at = None
             self._processing_alert_sent = False
+            self._last_problem_alert_category = None
 
     async def _restart_processing_loop(self) -> None:
         if self.recovery_in_progress or self._stopping:

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -99,7 +99,7 @@ def test_refresh_failure_alert_sent_once_on_state_change(monkeypatch):
         return DummyResponse(400)
 
     monkeypatch.setattr(httpx, "post", fake_post)
-    monkeypatch.setattr("app.google_auth.send_telegram_alert", fake_send)
+    monkeypatch.setattr("app.alerts.send_telegram_alert", fake_send)
 
     with pytest.raises(GoogleAuthError):
         asyncio.run(get_valid_google_access_token(session))
@@ -132,7 +132,7 @@ def test_refresh_success_after_failure_sends_recovery_once(monkeypatch):
     def ok_post(url, data, timeout):  # noqa: ARG001
         return DummyResponse(200, {"access_token": "new", "expires_in": 3600})
 
-    monkeypatch.setattr("app.google_auth.send_telegram_alert", fake_send)
+    monkeypatch.setattr("app.alerts.send_telegram_alert", fake_send)
     monkeypatch.setattr(httpx, "post", fail_post)
     with pytest.raises(GoogleAuthError):
         asyncio.run(get_valid_google_access_token(session))
@@ -145,8 +145,8 @@ def test_refresh_success_after_failure_sends_recovery_once(monkeypatch):
     assert state.auth_status == "ok"
     assert state.failure_count == 0
     assert len(sent) == 2
-    assert "failed" in sent[0]
-    assert "restored" in sent[1]
+    assert "Потеряна авторизация Google Contacts" in sent[0]
+    assert "Восстановлено" in sent[1]
     session.close()
 
 

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -92,8 +92,9 @@ def test_refresh_failure_alert_sent_once_on_state_change(monkeypatch):
 
     sent: list[str] = []
 
-    def fake_send(message: str) -> None:
+    def fake_send(message: str) -> bool:
         sent.append(message)
+        return True
 
     def fake_post(url, data, timeout):  # noqa: ARG001
         return DummyResponse(400)
@@ -123,8 +124,9 @@ def test_refresh_success_after_failure_sends_recovery_once(monkeypatch):
 
     sent: list[str] = []
 
-    def fake_send(message: str) -> None:
+    def fake_send(message: str) -> bool:
         sent.append(message)
+        return True
 
     def fail_post(url, data, timeout):  # noqa: ARG001
         return DummyResponse(400)
@@ -147,6 +149,28 @@ def test_refresh_success_after_failure_sends_recovery_once(monkeypatch):
     assert len(sent) == 2
     assert "Потеряна авторизация Google Contacts" in sent[0]
     assert "Восстановлено" in sent[1]
+    session.close()
+
+
+def test_refresh_failure_does_not_mark_alert_sent_when_telegram_failed(monkeypatch):
+    init_db()
+    session = get_session()
+    _reset_google_settings(session)
+    expiry = datetime.utcnow() - timedelta(seconds=10)
+    save_token(session, "google", "old", "refresh", expiry, scopes="")
+    mark_google_auth_ready(session)
+
+    def fail_post(url, data, timeout):  # noqa: ARG001
+        return DummyResponse(400)
+
+    monkeypatch.setattr(httpx, "post", fail_post)
+    monkeypatch.setattr("app.alerts.send_telegram_alert", lambda _: False)
+
+    with pytest.raises(GoogleAuthError):
+        asyncio.run(get_valid_google_access_token(session))
+
+    state = get_google_auth_state(session)
+    assert state.last_alert_sent_at is None
     session.close()
 
 

--- a/tests/test_pending_sync_worker.py
+++ b/tests/test_pending_sync_worker.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
+from app.alerts import AlertCategory
 from app.pending_sync_worker import PendingSyncWorker
 from app.storage import PendingSync, enqueue_pending_sync, get_session, init_db
 
@@ -39,3 +41,55 @@ async def test_worker_dead_letters_on_missing_amo_token(monkeypatch):
     assert stored_error.startswith("amo_auth_missing")
     assert stored_attempts == 1
     assert next_attempt_at > datetime.utcnow() + timedelta(days=3000)
+
+
+@pytest.mark.asyncio
+async def test_supervisor_recovery_uses_sent_problem_category(monkeypatch):
+    init_db()
+    worker = PendingSyncWorker()
+    worker._task = SimpleNamespace(done=lambda: False)
+    worker._stopping = False
+    worker._processing_stall_seconds = 1
+    worker.processing_last_heartbeat_at = datetime.utcnow() - timedelta(seconds=200)
+    worker.processing_last_success_at = datetime.utcnow() - timedelta(seconds=200)
+
+    class DummySession:
+        def close(self):
+            return None
+
+    monkeypatch.setattr("app.pending_sync_worker.get_session", lambda: DummySession())
+    monkeypatch.setattr(
+        "app.pending_sync_worker.get_pending_sync_health_stats",
+        lambda _session: {"queue_pending_count": 3},
+    )
+    monkeypatch.setattr("app.pending_sync_worker.settings.alert_grace_seconds", 0)
+    async def fake_restart(self):
+        return None
+
+    monkeypatch.setattr("app.pending_sync_worker.PendingSyncWorker._restart_processing_loop", fake_restart)
+
+    problem_categories = []
+    recovery_categories = []
+
+    def fake_problem(category, technical=None):
+        problem_categories.append(category)
+        return True
+
+    def fake_recovery(category, technical=None):
+        recovery_categories.append(category)
+        return True
+
+    monkeypatch.setattr("app.pending_sync_worker.send_problem_alert", fake_problem)
+    monkeypatch.setattr("app.pending_sync_worker.send_recovery_alert", fake_recovery)
+
+    await worker._supervisor_check()
+    monkeypatch.setattr(
+        "app.pending_sync_worker.get_pending_sync_health_stats",
+        lambda _session: {"queue_pending_count": 0},
+    )
+    worker.processing_last_heartbeat_at = datetime.utcnow()
+    worker.processing_last_success_at = datetime.utcnow()
+    await worker._supervisor_check()
+
+    assert problem_categories == [AlertCategory.QUEUE_BACKLOG_UNRECOVERED]
+    assert recovery_categories == [AlertCategory.QUEUE_BACKLOG_UNRECOVERED]


### PR DESCRIPTION
### Motivation
- Normalize Telegram alerts so they are only sent when actionable, suppress short self-healed noise, and provide clear Russian-language instructions. 
- Ensure every alert identifies the service, the problem, whether manual action is required, what to do, and a link when applicable. 
- Make the alert formatter/dispatcher extensible for future services and categories while implementing behavior for the current AmoCRM Google Contacts Sync service. 

### Description
- Added a reusable alert module `app/alerts.py` with explicit `AlertCategory` codes, per-category templates (title, `requires_manual_action`, `action_text`, `action_url`), and a standardized Russian message builder and `send_problem_alert`/`send_recovery_alert` dispatchers. 
- Exposed new environment settings in `app/config.py`: `ALERT_GRACE_SECONDS`, `TELEGRAM_ALERT_LANGUAGE`, `SERVICE_DISPLAY_NAME`, and `RENDER_SERVICE_DASHBOARD_URL`. 
- Integrated the new alert system into Google auth flow in `app/google_auth.py` to send a Russian actionable reauth alert (`google_auth_reauth_required`) and to only send recovery alerts when an initial alert was actually sent. 
- Updated supervisor logic in `app/pending_sync_worker.py` to implement a grace window suppression using `settings.alert_grace_seconds`, track problem detection time, send unrecovered alerts only after the grace window, and only send recovery alerts if an unrecovered alert was previously emitted; added structured log events for suppression/sent/recovery-skipped scenarios. 
- Updated tests to reflect Russian user-facing alert text and new dispatch integration in `tests/test_google.py`. 

### Testing
- Ran the focused test suite `pytest -q tests/test_google.py tests/test_pending_sync_worker.py`, which passed (`7 tests`). 
- Unit tests were adapted to stub `app.alerts.send_telegram_alert` and assert the new Russian message content and recovery-suppression behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ffe73ef9c832785dff1e0212c2287)