### PR TITLE
AGC-022: reduce heartbeat log noise and fix service log formatting

### DIFF
--- a/app/alerts.py
+++ b/app/alerts.py
@@ -92,7 +92,7 @@ def send_problem_alert(category: AlertCategory, *, technical: Optional[str] = No
     sent = send_telegram_alert(message)
     if not sent:
         return False
-    logger.info("telegram_alert.sent_manual_action_required category=%s", category.value)
+    logger.info("telegram_alert.sent_manual_action_required category={}", category.value)
     return True
 
 
@@ -111,5 +111,5 @@ def send_recovery_alert(category: AlertCategory, *, technical: Optional[str] = N
     sent = send_telegram_alert(message)
     if not sent:
         return False
-    logger.info("telegram_alert.recovery_sent category=%s", category.value)
+    logger.info("telegram_alert.recovery_sent category={}", category.value)
     return True

--- a/app/pending_sync_worker.py
+++ b/app/pending_sync_worker.py
@@ -202,7 +202,7 @@ class PendingSyncWorker:
                         await get_valid_google_access_token(session, force_refresh=True)
                     except GoogleAuthError as exc:
                         logger.warning(
-                            "google_auth.refresh_failed reason=%s",
+                            "google_auth.refresh_failed reason={}",
                             exc.reason,
                         )
                     else:
@@ -268,7 +268,8 @@ class PendingSyncWorker:
             logger.info("pending_sync.queue_backlog_cleared")
         if dead_task or stalled or backlog_stalled:
             logger.error(
-                "pending_sync.processing_loop_stalled dead_task=%s stalled=%s backlog_stalled=%s heartbeat_age=%.1f success_age=%.1f pending_count=%s",
+                "pending_sync.processing_loop_stalled "
+                "dead_task={} stalled={} backlog_stalled={} heartbeat_age={:.1f} success_age={:.1f} pending_count={}",
                 dead_task,
                 stalled,
                 backlog_stalled,
@@ -296,7 +297,7 @@ class PendingSyncWorker:
             if self._processing_alert_sent and self._last_problem_alert_category is not None:
                 send_recovery_alert(self._last_problem_alert_category, technical=f"pending_count={pending_count}")
             else:
-                logger.info("telegram_alert.suppressed_auto_recovered elapsed=%.1f", elapsed)
+                logger.info("telegram_alert.suppressed_auto_recovered elapsed={:.1f}", elapsed)
                 logger.info("telegram_alert.recovery_skipped_no_initial_alert category=processing_loop_stalled_unrecovered")
             self._problem_detected_at = None
             self._processing_alert_sent = False
@@ -314,13 +315,12 @@ class PendingSyncWorker:
             loop = asyncio.get_running_loop()
             self._task = loop.create_task(self._run())
             self._processing_loop_restart_count += 1
-            logger.warning("pending_sync.processing_loop_restarted count=%s", self._processing_loop_restart_count)
+            logger.warning("pending_sync.processing_loop_restarted count={}", self._processing_loop_restart_count)
         finally:
             self.recovery_in_progress = False
 
     def _heartbeat_processing(self, reason: str) -> None:
         self.processing_last_heartbeat_at = datetime.utcnow()
-        logger.debug("pending_sync.processing_loop_heartbeat reason=%s", reason)
 
     async def _handle_record(self, session, record: PendingSync) -> None:
         contact_id = int(record.amo_contact_id)


### PR DESCRIPTION
### Motivation
- Reduce frequent heartbeat noise in production Render logs while keeping heartbeat diagnostics available via debug/status endpoints.
- Ensure log messages render real values instead of literal printf-style templates like `%s`/`%.1f` to improve observability.

### Description
- Stop emitting the per-iteration heartbeat log by removing the `logger.debug("pending_sync.processing_loop_heartbeat ...")` call in `PendingSyncWorker._heartbeat_processing` while still updating `processing_last_heartbeat_at` in `app/pending_sync_worker.py`.
- Replace printf-style placeholders with Loguru-compatible format placeholders (`{}` / `{:.1f}`) for operational messages in `app/pending_sync_worker.py` (e.g. `processing_loop_stalled`, `processing_loop_restarted`, `telegram_alert.suppressed_auto_recovered`) and for the `google_auth.refresh_failed` warning in the refresh loop.
- Fix alert log formatting in `app/alerts.py` so `category` is logged with its real value instead of a `%s` template.
- Changes are limited to logging frequency/formatting; no business logic, recovery, alert behavior, or debug endpoint payloads were modified.

### Testing
- Ran focused tests: `pytest -q tests/test_pending_sync_worker.py tests/test_debug.py` and all tests passed (`17 passed`).
- No regressions in worker/debug behavior detected by the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10115c02248327b005a8a98ebd6992)